### PR TITLE
fix: Correct the API request for prompt refinement

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,12 +47,14 @@ type UpdatePromptRequest struct {
 	Prompt string `json:"prompt"`
 }
 
+type ResponseFormat struct {
+	Type string `json:"type"`
+}
+
 type OpenAIRequest struct {
-	Model          string    `json:"model"`
-	Messages       []Message `json:"messages"`
-	ResponseFormat struct {
-		Type string `json:"type"`
-	} `json:"response_format"`
+	Model          string          `json:"model"`
+	Messages       []Message       `json:"messages"`
+	ResponseFormat *ResponseFormat `json:"response_format,omitempty"`
 }
 
 type Message struct {
@@ -847,8 +849,8 @@ func handleGenerate(w http.ResponseWriter, r *http.Request) {
 				Content: finalPrompt,
 			},
 		},
+		ResponseFormat: &ResponseFormat{Type: "json_object"},
 	}
-	openaiReq.ResponseFormat.Type = "json_object"
 
 	// Marshal request
 	reqBody, err := json.Marshal(openaiReq)


### PR DESCRIPTION
This change fixes a bug where the prompt refinement step was silently failing, preventing the "last refined prompt" from ever being stored.

The root cause was a malformed API request. The `response_format` field in the `OpenAIRequest` was being sent with an empty `type`, which the OpenAI API rejected.

The fix involves refactoring the `OpenAIRequest` struct:
1.  A new `ResponseFormat` struct was created.
2.  The `OpenAIRequest.ResponseFormat` field was changed to be a pointer to the new struct (`*ResponseFormat`) and tagged with `omitempty`.

This ensures that the `response_format` field is completely omitted from the JSON payload when it's not explicitly set (as in the refinement call), and correctly included when it is (as in the exercise generation call).