### PR TITLE
fix: Restore login button functionality

### DIFF
--- a/app.js
+++ b/app.js
@@ -1066,6 +1066,10 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
 
+    loginBtn.addEventListener('click', () => {
+        window.location.href = '/auth/google/login';
+    });
+
     statsBtn.addEventListener('click', showUserExerciseStats);
 
     statsCloseBtn.addEventListener('click', () => {


### PR DESCRIPTION
The event listener for the 'Login with Google' button was accidentally removed during a previous refactoring. This commit restores the event listener in `app.js` to make the login button functional again.