### PR TITLE
fix: agent-friendly gct --help; drain bearer Touch goroutine in tests

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -56,26 +56,111 @@ func printVersion(w io.Writer) {
 	fmt.Fprintf(w, "gct %s (commit %s, %s)\n", v, c, runtime.Version())
 }
 
-// usage prints the top-level help. Subcommand-specific help is delegated to
-// each subcommand's *flag.FlagSet (-h / --help on `gct topics`, etc.).
+// usage prints the top-level help. It is written for both humans and AI
+// agents: any non-interactive caller should be able to drive the CLI from
+// this text alone without reading source. Subcommand-specific help is
+// delegated to each subcommand's *flag.FlagSet (`gct topics -h`, etc.).
 const usage = `gct — German Conjunctions Trainer CLI
+
+Lets you (or an AI agent) manage topics and trigger exercise generation
+against a German Conjunctions Trainer server without using the web UI.
 
 Usage:
   gct <command> [flags]
 
 Commands:
   login      Authenticate via Google OAuth (device flow) and save a bearer token
-  logout     Clear the locally-stored token
-  whoami     Show the currently-configured user and server
+  logout     Clear the locally-stored token (does not revoke on the server)
+  whoami     Print the currently-configured user and server URL
   topics     Manage topics (list, get, create, update, delete, move)
   exercises  Trigger exercise generation for a topic
   version    Print version and exit
 
 Global flags (apply to most subcommands):
-  --server URL    Server base URL (overrides config)
-  --config PATH   Config file path (overrides $GCT_CONFIG / XDG default)
-  --token TOKEN   Bearer token (overrides config)
-  --json          Emit raw JSON instead of human-readable output
+  --server URL    Server base URL (e.g. https://trainer.example.com)
+  --config PATH   Config file path (overrides $GCT_CONFIG / XDG default
+                  ~/.config/gct/config.json)
+  --token TOKEN   Bearer token (overrides config and $GCT_TOKEN)
+  --json          Emit raw JSON instead of human-readable output — use this
+                  when parsing programmatically
+
+============================================================================
+AGENT QUICKSTART — how to use gct from a non-interactive shell
+============================================================================
+
+1. AUTHENTICATE. Two options:
+
+   a) Run 'gct login --server https://trainer.example.com' once interactively.
+      It prints a short code and the URL https://www.google.com/device.
+      Open that URL in any browser, enter the code, finish Google sign-in.
+      The bearer token is saved to ~/.config/gct/config.json (mode 0600).
+      Subsequent gct invocations are fully non-interactive.
+
+   b) Skip 'gct login' entirely: set GCT_TOKEN=<bearer-token> and pass
+      --server URL (or persist it once via 'gct login' on another host).
+      Tokens are issued by the server's POST /api/auth/cli-exchange endpoint;
+      the admin can mint one on your behalf.
+
+   'gct whoami' confirms auth. If it prints "User: <uuid>" you are good.
+   "not logged in" or "token rejected by server" → fix auth first; no other
+   subcommand will work.
+
+2. DISCOVER TOPICS.
+
+     gct topics list --json          # full flat list, machine-parseable
+     gct topics list --tree          # indented tree, human-readable
+     gct topics get <id> --json      # one topic with its full prompt body
+
+3. MUTATE TOPICS (admin permission required — server returns 403 otherwise).
+
+     gct topics create --name "Modal verbs" --prompt-file ./modal.md
+     gct topics update <id> --prompt-file ./new-prompt.md
+     gct topics update <id> --name "Modal verbs (revised)"
+     gct topics move   <id> --parent <parent-id> [--position N]
+     gct topics move   <id> --no-parent              # move to root
+     gct topics delete <id> --yes                    # skip confirmation
+
+   Tip for agents: use --prompt-file rather than --prompt for anything
+   non-trivial. Pass "-" to read the prompt body from stdin:
+     cat prompt.md | gct topics create --name X --prompt-file -
+
+4. GENERATE EXERCISES for a topic.
+
+     gct topics list --json \
+       | jq -r '.[] | select(.name=="Modal verbs").id' \
+       | xargs gct exercises generate
+     gct exercises generate <topic-id> --watch    # poll until ≥10 exercises
+     gct exercises generate <topic-id> --json     # raw exercise array
+
+5. EXIT CODES.
+
+     0  success
+     1  runtime error (auth rejected, server error, network failure)
+     2  usage error (bad flags / missing arguments)
+
+   Stderr carries diagnostics; stdout carries data. Safe to capture stdout
+   for parsing without filtering.
+
+6. ENVIRONMENT VARIABLES (alternatives to flags).
+
+     GCT_TOKEN                 Bearer token (used when config has no token)
+     GCT_CONFIG                Path to config file
+     GCT_GOOGLE_CLIENT_ID      Override the baked-in Google OAuth client ID
+     GCT_GOOGLE_CLIENT_SECRET  Override the baked-in Google OAuth client secret
+
+   The two GCT_GOOGLE_* vars are only needed for 'gct login' on a build
+   that wasn't compiled with -ldflags credentials. Once you have a token,
+   the CLI no longer touches Google at all.
+
+7. TROUBLESHOOTING.
+
+     - "not logged in" → run 'gct login' or export GCT_TOKEN
+     - "token rejected by server" → token revoked or expired; 'gct login' again
+     - "admin permission required" (403) → your Google account is not the
+       admin configured on the server; ask the admin to either grant access
+       or run mutating commands themselves
+     - HTTP 4xx on create/update → the body printed after the status code is
+       the server's validation message (e.g. duplicate name, prompt too short)
 `
 
 func main() {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -39,6 +39,21 @@ type App struct {
 	clients            map[string]*rateclient
 	mu                 sync.Mutex
 	shutdown           chan struct{} // Channel to signal goroutine shutdown
+	// bgWG tracks per-request fire-and-forget goroutines (currently only the
+	// async TouchCLIToken update in resolveBearer). It lets tests drain
+	// these workers before t.TempDir() cleanup deletes the sqlite database,
+	// avoiding "attempt to write a readonly database" races and
+	// "directory not empty" cleanup failures observed in CI.
+	bgWG sync.WaitGroup
+}
+
+// WaitBackground blocks until all per-request background goroutines launched
+// via a.bgWG have finished. Intended for tests; production code can call it
+// during shutdown if it wants a clean drain, but the long-lived background
+// jobs started in New are gated on a.shutdown instead and are not counted
+// here.
+func (a *App) WaitBackground() {
+	a.bgWG.Wait()
 }
 
 // ElevenLabsConfig holds ElevenLabs TTS configuration.

--- a/internal/app/middleware.go
+++ b/internal/app/middleware.go
@@ -78,7 +78,9 @@ func (a *App) resolveBearer(r *http.Request) (string, bearerAuthResult) {
 	if tok == nil || tok.RevokedAt != nil {
 		return "", bearerInvalid
 	}
+	a.bgWG.Add(1)
 	go func(id string) {
+		defer a.bgWG.Done()
 		if err := a.DB.TouchCLIToken(id); err != nil {
 			log.Printf("[AUTH] TouchCLIToken(%s) failed: %v", id, err)
 		}

--- a/internal/app/middleware_test.go
+++ b/internal/app/middleware_test.go
@@ -17,6 +17,13 @@ import (
 // setupAuthTestApp builds an App backed by a fresh on-disk SQLite store and
 // a deterministic securecookie codec so tests can mint valid session
 // cookies through app.SC.Encode.
+//
+// The cleanup hook drains any background goroutines launched by
+// resolveBearer (the async TouchCLIToken update) before closing the
+// SQLite handle. Without this, the goroutine can write to the database
+// after t.TempDir() removes the WAL/SHM sidecars, producing flaky
+// "directory not empty" cleanup errors and "attempt to write a readonly
+// database" log lines that bleed into adjacent tests.
 func setupAuthTestApp(t *testing.T) *App {
 	t.Helper()
 	dbPath := filepath.Join(t.TempDir(), "test.db")
@@ -25,7 +32,14 @@ func setupAuthTestApp(t *testing.T) *App {
 		t.Fatalf("NewSQLiteStorage: %v", err)
 	}
 	sc := securecookie.New(securecookie.GenerateRandomKey(64), securecookie.GenerateRandomKey(32))
-	return &App{DB: store, SC: sc}
+	app := &App{DB: store, SC: sc}
+	t.Cleanup(func() {
+		app.WaitBackground()
+		if err := store.Close(); err != nil {
+			t.Logf("storage close: %v", err)
+		}
+	})
+	return app
 }
 
 // issueToken creates a CLI token row for userID and returns the plaintext


### PR DESCRIPTION
## Summary

Two fixes follow-on from #78:

1. **`gct --help` is now agent-friendly.** The top-level help text gained an "AGENT QUICKSTART" with the full workflow (auth → discover → mutate → generate), env vars, exit codes, and troubleshooting. The intent is that an AI agent can drive `gct` from a non-interactive shell using `--help` alone.

2. **Fix the flaky middleware test cleanup that failed on master post-merge.** `TestWithAuth_BearerWinsOverCookie` failed with:
   - `TempDir RemoveAll cleanup: ... directory not empty`
   - `[AUTH] TouchCLIToken(...) failed: attempt to write a readonly database`

   `resolveBearer` fires `TouchCLIToken` as a fire-and-forget goroutine to keep request latency low. Without coordination, this race leaks past test end into the next test's setup, and the SQLite WAL/SHM sidecars are still held when `t.TempDir()` cleanup tries to remove the directory.

   Tracked the goroutine via a new `App.bgWG sync.WaitGroup` with a `WaitBackground()` method. `setupAuthTestApp` now drains the WG and closes the store in `t.Cleanup`.

## Test plan

- [ ] CI green (`go-tests.yml`, `docker-build-pr.yml`, `vitest.yml`)
- [ ] `go test ./...` locally — passes (verified)
- [ ] `./gct --help` shows the new AGENT QUICKSTART section (verified)