### PR TITLE
feat: mint CLI tokens from web UI; sidestep Google device-flow restrictions

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -69,7 +69,8 @@ Usage:
   gct <command> [flags]
 
 Commands:
-  login      Authenticate via Google OAuth (device flow) and save a bearer token
+  auth       Manage CLI auth without Google device flow (set-token)
+  login      Authenticate via Google OAuth device flow (legacy; see step 1c)
   logout     Clear the locally-stored token (does not revoke on the server)
   whoami     Print the currently-configured user and server URL
   topics     Manage topics (list, get, create, update, delete, move)
@@ -88,18 +89,31 @@ Global flags (apply to most subcommands):
 AGENT QUICKSTART — how to use gct from a non-interactive shell
 ============================================================================
 
-1. AUTHENTICATE. Two options:
+1. AUTHENTICATE. Pick whichever fits your setup — all three end with a
+   bearer token on disk that subsequent commands use non-interactively.
 
-   a) Run 'gct login --server https://trainer.example.com' once interactively.
-      It prints a short code and the URL https://www.google.com/device.
-      Open that URL in any browser, enter the code, finish Google sign-in.
-      The bearer token is saved to ~/.config/gct/config.json (mode 0600).
-      Subsequent gct invocations are fully non-interactive.
+   a) RECOMMENDED — mint a token from the web UI:
+        - Open the web app in any browser, sign in with your Google admin
+          account (you have to be the admin configured on the server).
+        - Open the Settings modal → "CLI Access" → click "Generate token".
+        - Copy the token (shown once), then on the CLI host:
+            gct auth set-token <PASTED_TOKEN> --server https://trainer.example.com
+        - No GCP setup required.
 
-   b) Skip 'gct login' entirely: set GCT_TOKEN=<bearer-token> and pass
-      --server URL (or persist it once via 'gct login' on another host).
-      Tokens are issued by the server's POST /api/auth/cli-exchange endpoint;
-      the admin can mint one on your behalf.
+   b) Mint via curl using your browser session cookie (if you don't want to
+      use the UI):
+        curl -X POST https://trainer.example.com/api/auth/cli-tokens \
+             -H "Cookie: user-session=<COOKIE_FROM_DEVTOOLS>" \
+             -d '{"label":"server"}'
+      Then:  gct auth set-token <token> --server https://trainer.example.com
+
+   c) Google device flow (legacy): 'gct login --server URL'. Requires a
+      "TVs and Limited Input devices" OAuth client in GCP (Google's device
+      endpoint refuses other client types) plus GCT_GOOGLE_CLIENT_ID /
+      GCT_GOOGLE_CLIENT_SECRET env vars. Most users should prefer (a).
+
+   d) For agents / CI: set GCT_TOKEN=<bearer-token> in the environment plus
+      --server URL. No config file needed.
 
    'gct whoami' confirms auth. If it prints "User: <uuid>" you are good.
    "not logged in" or "token rejected by server" → fix auth first; no other
@@ -186,6 +200,8 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	case "version", "--version", "-v":
 		printVersion(stdout)
 		return 0
+	case "auth":
+		return runAuth(rest, stdout, stderr)
 	case "login":
 		return runLogin(rest, stdout, stderr)
 	case "logout":
@@ -251,6 +267,96 @@ func runLogin(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	fmt.Fprintf(stdout, "Logged in as %s (label: %s)\n", res.UserID, res.Label)
+	return 0
+}
+
+// authUsage documents the `gct auth` subcommands. set-token is the primary
+// path for users who'd rather not deal with Google's device-flow OAuth
+// client-type restrictions — they generate a token in the web UI (or via
+// curl against /api/auth/cli-tokens) and persist it locally with one
+// command.
+const authUsage = `gct auth — manage CLI credentials without Google OAuth
+
+Usage:
+  gct auth set-token <TOKEN> [--server URL] [--config PATH]
+
+The token comes from the server's "CLI Access" settings panel (admin only)
+or from a direct call to POST /api/auth/cli-tokens with your web session
+cookie. After set-token, run 'gct whoami' to confirm.
+`
+
+// runAuth dispatches `gct auth <sub>` subcommands.
+func runAuth(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		fmt.Fprint(stderr, authUsage)
+		return 2
+	}
+	sub, rest := args[0], args[1:]
+	switch sub {
+	case "-h", "--help", "help":
+		fmt.Fprint(stdout, authUsage)
+		return 0
+	case "set-token":
+		return runAuthSetToken(rest, stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "gct auth: unknown subcommand %q\n\n", sub)
+		fmt.Fprint(stderr, authUsage)
+		return 2
+	}
+}
+
+// runAuthSetToken persists a manually-supplied bearer token to the config
+// file. Intended for the workflow "admin mints token in the web UI, pastes
+// it into the CLI host". --server is optional if the config already has a
+// server URL; otherwise it's required so subsequent commands know where
+// to talk.
+func runAuthSetToken(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("auth set-token", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		server     = fs.String("server", "", "Server base URL (required if not already in config)")
+		configPath = fs.String("config", "", "Config file path (overrides $GCT_CONFIG)")
+	)
+	if err := fs.Parse(reorderArgs(args)); err != nil {
+		return 2
+	}
+	if fs.NArg() < 1 {
+		fmt.Fprintln(stderr, "gct auth set-token: token argument required")
+		fmt.Fprintln(stderr, "usage: gct auth set-token <TOKEN> [--server URL]")
+		return 2
+	}
+	if fs.NArg() > 1 {
+		fmt.Fprintf(stderr, "gct auth set-token: expected exactly one token, got %d\n", fs.NArg())
+		return 2
+	}
+	token := strings.TrimSpace(fs.Arg(0))
+	if token == "" {
+		fmt.Fprintln(stderr, "gct auth set-token: token cannot be empty")
+		return 2
+	}
+
+	cfg, err := loadConfig(*configPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "gct auth set-token: %v\n", err)
+		return 1
+	}
+	if *server != "" {
+		cfg.ServerURL = *server
+	}
+	if cfg.ServerURL == "" {
+		fmt.Fprintln(stderr, "gct auth set-token: server URL is required — pass --server URL or run 'gct login --server URL' first")
+		return 2
+	}
+	cfg.Token = token
+	// Clear the cached UserID — it belonged to the previous token (if any)
+	// and would be misleading if the new token is for a different user. The
+	// next `gct whoami` call will re-populate it from /api/auth/status.
+	cfg.UserID = ""
+	if err := saveConfig(cfg, *configPath); err != nil {
+		fmt.Fprintf(stderr, "gct auth set-token: save config: %v\n", err)
+		return 1
+	}
+	fmt.Fprintln(stdout, "Token saved. Run 'gct whoami' to verify.")
 	return 0
 }
 

--- a/cmd/cli/main_test.go
+++ b/cmd/cli/main_test.go
@@ -55,6 +55,115 @@ func runTopicsCmd(t *testing.T, stdin io.Reader, args ...string) (int, string, s
 	return code, stdout.String(), stderr.String()
 }
 
+// readSavedConfig parses the on-disk config file written by run(...) so tests
+// can assert against the post-command state without re-implementing the
+// XDG lookup logic.
+func readSavedConfig(t *testing.T, path string) cliConfig {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	var got cliConfig
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal config: %v", err)
+	}
+	return got
+}
+
+func TestAuthSetTokenPersistsToken(t *testing.T) {
+	path := withConfig(t, cliConfig{ServerURL: "https://prev.example.com", Token: "old-token", UserID: "old-user"})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"auth", "set-token", "new-token-123"}, nil, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr=%s", code, stderr.String())
+	}
+	cfg := readSavedConfig(t, path)
+	if cfg.Token != "new-token-123" {
+		t.Errorf("Token = %q, want new-token-123", cfg.Token)
+	}
+	if cfg.ServerURL != "https://prev.example.com" {
+		t.Errorf("ServerURL = %q, expected to be preserved", cfg.ServerURL)
+	}
+	if cfg.UserID != "" {
+		t.Errorf("UserID = %q, want empty (cleared)", cfg.UserID)
+	}
+	if !strings.Contains(stdout.String(), "Token saved") {
+		t.Errorf("stdout missing confirmation: %q", stdout.String())
+	}
+}
+
+func TestAuthSetTokenWithServerFlag(t *testing.T) {
+	path := withConfig(t, cliConfig{})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"auth", "set-token", "tok", "--server", "https://new.example.com"}, nil, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr=%s", code, stderr.String())
+	}
+	cfg := readSavedConfig(t, path)
+	if cfg.ServerURL != "https://new.example.com" {
+		t.Errorf("ServerURL = %q", cfg.ServerURL)
+	}
+	if cfg.Token != "tok" {
+		t.Errorf("Token = %q", cfg.Token)
+	}
+}
+
+func TestAuthSetTokenRequiresServer(t *testing.T) {
+	withConfig(t, cliConfig{})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"auth", "set-token", "tok"}, nil, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "server URL is required") {
+		t.Errorf("stderr missing expected message: %q", stderr.String())
+	}
+}
+
+func TestAuthSetTokenRequiresArg(t *testing.T) {
+	withConfig(t, cliConfig{ServerURL: "https://x.example.com"})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"auth", "set-token"}, nil, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2", code)
+	}
+	if !strings.Contains(stderr.String(), "token argument required") {
+		t.Errorf("stderr missing expected message: %q", stderr.String())
+	}
+}
+
+func TestAuthSetTokenRejectsEmptyToken(t *testing.T) {
+	withConfig(t, cliConfig{ServerURL: "https://x.example.com"})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"auth", "set-token", "   "}, nil, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2; stderr=%s", code, stderr.String())
+	}
+}
+
+func TestAuthHelpListsSubcommands(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"auth", "--help"}, nil, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "set-token") {
+		t.Errorf("auth --help missing set-token: %q", stdout.String())
+	}
+}
+
+func TestAuthUnknownSubcommand(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"auth", "wibble"}, nil, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2", code)
+	}
+	if !strings.Contains(stderr.String(), `unknown subcommand "wibble"`) {
+		t.Errorf("stderr missing message: %q", stderr.String())
+	}
+}
+
 func TestTopicsListPrintsTabularByDefault(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/topics" || r.Method != http.MethodGet {

--- a/index.html
+++ b/index.html
@@ -359,6 +359,36 @@ Situations: [contexts, e.g. explaining reasons, expressing goals, giving instruc
                 </div>
             </div>
 
+            <!-- CLI Access (admin only) -->
+            <div id="cli-access-section" class="mb-6 hidden">
+                <div class="db-stats-separator"></div>
+                <h3 class="section-title mb-2">CLI Access</h3>
+                <p class="section-desc mb-3">
+                    Generate a bearer token for the <code>gct</code> command-line tool.
+                    The token grants the same permissions as your current admin session.
+                    Save the token now — it is shown only once.
+                </p>
+                <div class="flex items-center gap-2 mb-3">
+                    <label for="cli-token-label" class="text-label">Label:</label>
+                    <input type="text" id="cli-token-label" class="form-input" placeholder="laptop" maxlength="64" style="max-width: 16rem;">
+                    <button id="cli-token-generate-btn" class="btn-primary btn-sm">Generate token</button>
+                </div>
+                <div id="cli-token-result" class="hidden">
+                    <label class="text-label block mb-1">Token (copy now):</label>
+                    <div class="flex items-center gap-2 mb-2">
+                        <input type="text" id="cli-token-value" class="form-input flex-1" readonly>
+                        <button id="cli-token-copy-btn" class="btn-secondary btn-sm">Copy</button>
+                    </div>
+                    <details>
+                        <summary class="db-stats-summary">How to use this token</summary>
+                        <pre class="cli-token-snippet mt-2"># On the machine that will run gct:
+gct auth set-token &lt;PASTED_TOKEN&gt; --server &lt;THIS_SERVER_URL&gt;
+gct whoami</pre>
+                    </details>
+                </div>
+                <div id="cli-token-error" class="text-error text-sm hidden mt-2"></div>
+            </div>
+
             <div class="flex justify-end">
                 <button id="settings-close-btn" class="btn-secondary">Close</button>
             </div>

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -177,6 +177,11 @@ func (a *App) RegisterRoutes() {
 	http.HandleFunc("/auth/logout", a.handleLogout)
 	http.HandleFunc("/api/auth/is_admin", a.withOptionalAuth(a.handleIsAdmin))
 	http.HandleFunc("/api/auth/cli-exchange", a.handleCLIExchange)
+	// /api/auth/cli-tokens mints a CLI bearer token using the caller's
+	// existing web session (cookie or bearer). Admin-only because issuing a
+	// token equals long-lived programmatic write access to topics — we don't
+	// want every reader-class user minting them.
+	http.HandleFunc("/api/auth/cli-tokens", a.withAuth(a.adminOnly(a.handleCreateCLIToken)))
 
 	http.HandleFunc("/api/user/stats", a.withAuth(a.handleUserStats))
 	http.HandleFunc("/api/user/settings", a.withAuth(a.handleUserSettings))

--- a/internal/app/auth.go
+++ b/internal/app/auth.go
@@ -256,16 +256,7 @@ func (a *App) handleCLIExchange(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	raw := make([]byte, 32)
-	if _, err := rand.Read(raw); err != nil {
-		writeJSONError(w, http.StatusInternalServerError, "TOKEN_GENERATION_FAILED", "Failed to generate token", err.Error(), false)
-		return
-	}
-	plaintext := "gct_" + base64.RawURLEncoding.EncodeToString(raw)
-	sum := sha256.Sum256([]byte(plaintext))
-	hash := hex.EncodeToString(sum[:])
-
-	tok, err := a.DB.CreateCLIToken(user.ID, hash, label)
+	plaintext, tokenID, err := a.mintCLIToken(user.ID, label)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "TOKEN_PERSIST_FAILED", "Failed to persist token", err.Error(), false)
 		return
@@ -275,8 +266,81 @@ func (a *App) handleCLIExchange(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusCreated)
 	_ = json.NewEncoder(w).Encode(map[string]string{
 		"token":    plaintext,
-		"token_id": tok.ID,
+		"token_id": tokenID,
 		"user_id":  user.ID,
+	})
+}
+
+// mintCLIToken generates a fresh "gct_…" bearer token for the given user,
+// persists its SHA-256 hash under the supplied label, and returns the
+// plaintext token plus the row ID. Shared between handleCLIExchange (Google
+// OAuth path) and handleCreateCLIToken (cookie/admin path) so the token
+// format, hash algorithm, and storage call live in one place.
+func (a *App) mintCLIToken(userID, label string) (plaintext, tokenID string, err error) {
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		return "", "", err
+	}
+	plaintext = "gct_" + base64.RawURLEncoding.EncodeToString(raw)
+	sum := sha256.Sum256([]byte(plaintext))
+	hash := hex.EncodeToString(sum[:])
+
+	tok, err := a.DB.CreateCLIToken(userID, hash, label)
+	if err != nil {
+		return "", "", err
+	}
+	return plaintext, tok.ID, nil
+}
+
+// handleCreateCLIToken mints a CLI bearer token for the authenticated user
+// using their existing web session. This is the simpler alternative to
+// handleCLIExchange: instead of requiring the CLI to complete a Google
+// device-authorization flow (which now forces operators to register a
+// "TVs and Limited Input devices" OAuth client in GCP), the admin logs into
+// the web UI, hits the CLI section, and copy-pastes a token. Wrapped by
+// adminOnly in the route table so only configured admins can mint tokens.
+func (a *App) handleCreateCLIToken(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeJSONError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Method not allowed", "", false)
+		return
+	}
+
+	userID := getUserIDFromRequest(r)
+	if userID == "" {
+		// Defensive — adminOnly already required auth, but this keeps the
+		// handler safe to wire under different middleware later.
+		writeJSONError(w, http.StatusUnauthorized, "NOT_AUTHENTICATED", "You must be logged in to mint a CLI token", "", false)
+		return
+	}
+
+	var req struct {
+		Label string `json:"label"`
+	}
+	// Body is optional — empty/no body is treated as label="cli".
+	if r.ContentLength > 0 {
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSONError(w, http.StatusBadRequest, "INVALID_REQUEST_BODY", "Invalid request body", err.Error(), false)
+			return
+		}
+	}
+	label := strings.TrimSpace(req.Label)
+	if label == "" {
+		label = "cli"
+	}
+
+	plaintext, tokenID, err := a.mintCLIToken(userID, label)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "TOKEN_PERSIST_FAILED", "Failed to persist token", err.Error(), false)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"token":    plaintext,
+		"token_id": tokenID,
+		"user_id":  userID,
+		"label":    label,
 	})
 }
 

--- a/internal/app/cli_tokens_handler_test.go
+++ b/internal/app/cli_tokens_handler_test.go
@@ -1,0 +1,166 @@
+package app
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// callCreateCLIToken posts to /api/auth/cli-tokens through the same
+// withAuth(adminOnly(...)) chain that the real route table installs, so the
+// test exercises the actual auth wiring rather than just the bare handler.
+func callCreateCLIToken(t *testing.T, app *App, body string, userIDInContext string) *httptest.ResponseRecorder {
+	t.Helper()
+	handler := app.withAuth(app.adminOnly(app.handleCreateCLIToken))
+	var reader *strings.Reader
+	if body != "" {
+		reader = strings.NewReader(body)
+	}
+	var req *http.Request
+	if reader != nil {
+		req = httptest.NewRequest(http.MethodPost, "/api/auth/cli-tokens", reader)
+	} else {
+		req = httptest.NewRequest(http.MethodPost, "/api/auth/cli-tokens", nil)
+	}
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	// We bypass withAuth's cookie/bearer parsing by setting the cookie
+	// directly using app.SC, which is how production also creates them.
+	if userIDInContext != "" {
+		encoded, err := app.SC.Encode(cookieName, userIDInContext)
+		if err != nil {
+			t.Fatalf("SC.Encode: %v", err)
+		}
+		req.AddCookie(&http.Cookie{Name: cookieName, Value: encoded})
+	}
+	rr := httptest.NewRecorder()
+	handler(rr, req)
+	return rr
+}
+
+// setupAdminApp builds an authenticated, admin-configured App and returns
+// the admin user's ID for cookie minting. Reuses setupAuthTestApp so the
+// background-goroutine drain in t.Cleanup applies here too.
+func setupAdminApp(t *testing.T) (*App, string) {
+	t.Helper()
+	app := setupAuthTestApp(t)
+	adminGoogleID := "google-admin-cli-tokens"
+	app.AdminGoogleID = adminGoogleID
+	user, err := app.DB.CreateUser(adminGoogleID)
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	return app, user.ID
+}
+
+func TestHandleCreateCLIToken_AdminSucceeds(t *testing.T) {
+	app, adminID := setupAdminApp(t)
+	rr := callCreateCLIToken(t, app, `{"label":"laptop"}`, adminID)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body=%q", rr.Code, rr.Body.String())
+	}
+
+	var resp map[string]string
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	plaintext := resp["token"]
+	if !strings.HasPrefix(plaintext, "gct_") || len(plaintext) != 4+43 {
+		t.Errorf("unexpected token shape: %q", plaintext)
+	}
+	if resp["label"] != "laptop" {
+		t.Errorf("label = %q, want %q", resp["label"], "laptop")
+	}
+	if resp["user_id"] != adminID {
+		t.Errorf("user_id = %q, want %q", resp["user_id"], adminID)
+	}
+
+	// The hash should be persisted and resolvable.
+	sum := sha256.Sum256([]byte(plaintext))
+	hash := hex.EncodeToString(sum[:])
+	tok, err := app.DB.GetCLITokenByHash(hash)
+	if err != nil || tok == nil {
+		t.Fatalf("expected token row, got tok=%v err=%v", tok, err)
+	}
+	if tok.UserID != adminID {
+		t.Errorf("persisted UserID = %q, want %q", tok.UserID, adminID)
+	}
+	if tok.Label != "laptop" {
+		t.Errorf("persisted Label = %q, want %q", tok.Label, "laptop")
+	}
+}
+
+func TestHandleCreateCLIToken_DefaultLabel(t *testing.T) {
+	app, adminID := setupAdminApp(t)
+	// Empty body — handler should accept it and default the label to "cli".
+	rr := callCreateCLIToken(t, app, ``, adminID)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body=%q", rr.Code, rr.Body.String())
+	}
+	var resp map[string]string
+	_ = json.NewDecoder(rr.Body).Decode(&resp)
+	if resp["label"] != "cli" {
+		t.Errorf("default label = %q, want %q", resp["label"], "cli")
+	}
+}
+
+func TestHandleCreateCLIToken_NonAdminForbidden(t *testing.T) {
+	app := setupAuthTestApp(t)
+	app.AdminGoogleID = "google-actual-admin"
+	other, _ := app.DB.CreateUser("google-not-admin")
+	rr := callCreateCLIToken(t, app, `{"label":"x"}`, other.ID)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403; body=%q", rr.Code, rr.Body.String())
+	}
+}
+
+func TestHandleCreateCLIToken_Unauthenticated(t *testing.T) {
+	app := setupAuthTestApp(t)
+	app.AdminGoogleID = "google-actual-admin"
+	rr := callCreateCLIToken(t, app, `{"label":"x"}`, "")
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401; body=%q", rr.Code, rr.Body.String())
+	}
+}
+
+func TestHandleCreateCLIToken_WrongMethod(t *testing.T) {
+	app, adminID := setupAdminApp(t)
+	handler := app.withAuth(app.adminOnly(app.handleCreateCLIToken))
+	encoded, _ := app.SC.Encode(cookieName, adminID)
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/cli-tokens", nil)
+	req.AddCookie(&http.Cookie{Name: cookieName, Value: encoded})
+	rr := httptest.NewRecorder()
+	handler(rr, req)
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", rr.Code)
+	}
+}
+
+func TestHandleCreateCLIToken_TokensAccumulate(t *testing.T) {
+	app, adminID := setupAdminApp(t)
+	tokens := map[string]bool{}
+	for i := 0; i < 3; i++ {
+		rr := callCreateCLIToken(t, app, `{"label":"server"}`, adminID)
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("call %d: status = %d", i, rr.Code)
+		}
+		var resp map[string]string
+		_ = json.NewDecoder(rr.Body).Decode(&resp)
+		if tokens[resp["token"]] {
+			t.Fatalf("duplicate token returned across calls: %q", resp["token"])
+		}
+		tokens[resp["token"]] = true
+	}
+	rows, err := app.DB.ListCLITokensForUser(adminID)
+	if err != nil {
+		t.Fatalf("ListCLITokensForUser: %v", err)
+	}
+	if len(rows) != 3 {
+		t.Errorf("got %d persisted tokens, want 3", len(rows))
+	}
+}

--- a/js/api.js
+++ b/js/api.js
@@ -256,3 +256,19 @@ export async function fetchDatabaseStatsAPI() {
     if (!response.ok) throw new Error('Failed to fetch database stats');
     return response.json();
 }
+
+// createCLITokenAPI mints a new bearer token for the `gct` CLI. Admin-only
+// on the server side; non-admins get a 403 that the caller should surface.
+export async function createCLITokenAPI(label) {
+    const response = await fetch('/api/auth/cli-tokens', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ label: label || 'cli' }),
+    });
+    if (!response.ok) {
+        let detail = '';
+        try { detail = (await response.json()).message || ''; } catch (_) {}
+        throw new Error(detail || `Failed to mint CLI token (HTTP ${response.status})`);
+    }
+    return response.json();
+}

--- a/js/dom.js
+++ b/js/dom.js
@@ -132,4 +132,13 @@ export const dom = {
     dbStatDbSize: document.getElementById('db-stat-db-size'),
     dbStatAudioCache: document.getElementById('db-stat-audio-cache'),
     dbStatsPerTopic: document.getElementById('db-stats-per-topic'),
+
+    // CLI access (admin only)
+    cliAccessSection: document.getElementById('cli-access-section'),
+    cliTokenLabel: document.getElementById('cli-token-label'),
+    cliTokenGenerateBtn: document.getElementById('cli-token-generate-btn'),
+    cliTokenResult: document.getElementById('cli-token-result'),
+    cliTokenValue: document.getElementById('cli-token-value'),
+    cliTokenCopyBtn: document.getElementById('cli-token-copy-btn'),
+    cliTokenError: document.getElementById('cli-token-error'),
 };

--- a/js/main.js
+++ b/js/main.js
@@ -54,7 +54,7 @@ import {
 import {
     checkAuthStatus,
 } from './auth.js';
-import { fetchDatabaseStatsAPI } from './api.js';
+import { fetchDatabaseStatsAPI, createCLITokenAPI } from './api.js';
 import {
     showExerciseHistory,
     renderHistoryPage,
@@ -90,7 +90,67 @@ dom.settingsBtn.addEventListener('click', () => {
     loadTopics(); // Refresh topics when opening settings
     dom.settingsModal.showModal();
     loadDatabaseStats();
+    toggleCLIAccessSection();
 });
+
+// --- CLI Access (admin only) ---
+// Shows or hides the "CLI Access" panel based on admin status, and clears
+// any token left over from a previous open. We never want a token to be
+// visible after the user closes and re-opens the modal — it was a one-time
+// reveal.
+function toggleCLIAccessSection() {
+    if (!dom.cliAccessSection) return;
+    if (!state.isAdmin) {
+        dom.cliAccessSection.classList.add('hidden');
+        return;
+    }
+    dom.cliAccessSection.classList.remove('hidden');
+    if (dom.cliTokenResult) dom.cliTokenResult.classList.add('hidden');
+    if (dom.cliTokenValue) dom.cliTokenValue.value = '';
+    if (dom.cliTokenError) {
+        dom.cliTokenError.classList.add('hidden');
+        dom.cliTokenError.textContent = '';
+    }
+}
+
+if (dom.cliTokenGenerateBtn) {
+    dom.cliTokenGenerateBtn.addEventListener('click', async () => {
+        dom.cliTokenError.classList.add('hidden');
+        dom.cliTokenError.textContent = '';
+        dom.cliTokenGenerateBtn.disabled = true;
+        try {
+            const label = (dom.cliTokenLabel.value || '').trim() || 'cli';
+            const result = await createCLITokenAPI(label);
+            dom.cliTokenValue.value = result.token || '';
+            dom.cliTokenResult.classList.remove('hidden');
+            dom.cliTokenValue.focus();
+            dom.cliTokenValue.select();
+        } catch (err) {
+            dom.cliTokenError.textContent = err.message || 'Failed to mint CLI token.';
+            dom.cliTokenError.classList.remove('hidden');
+        } finally {
+            dom.cliTokenGenerateBtn.disabled = false;
+        }
+    });
+}
+
+if (dom.cliTokenCopyBtn) {
+    dom.cliTokenCopyBtn.addEventListener('click', async () => {
+        const value = dom.cliTokenValue.value;
+        if (!value) return;
+        try {
+            await navigator.clipboard.writeText(value);
+            const original = dom.cliTokenCopyBtn.textContent;
+            dom.cliTokenCopyBtn.textContent = 'Copied!';
+            setTimeout(() => { dom.cliTokenCopyBtn.textContent = original; }, 1500);
+        } catch (_) {
+            // Clipboard API can fail (e.g. insecure context). Fall back to
+            // selecting the field so the user can ctrl/cmd-C themselves.
+            dom.cliTokenValue.focus();
+            dom.cliTokenValue.select();
+        }
+    });
+}
 
 dom.settingsCloseBtn.addEventListener('click', () => {
     dom.settingsModal.close();

--- a/style.css
+++ b/style.css
@@ -2157,6 +2157,20 @@ button:disabled.is-audio-off {
     overflow-y: auto;
 }
 
+/* CLI Access panel — admin-only token mint UI in the settings modal. */
+.cli-token-snippet {
+    background-color: var(--mr-surface);
+    border: 1px solid rgba(163, 63, 17, 0.15);
+    border-radius: 4px;
+    padding: var(--spacing-2);
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
+    font-size: 0.8125rem;
+    line-height: 1.5;
+    color: var(--mr-text);
+    white-space: pre-wrap;
+    word-break: break-all;
+}
+
 .db-stats-topic-row {
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
## Summary

Google's OAuth device endpoint now refuses any client type other than "TVs and Limited Input devices" (`gct login` returns `invalid_client` against a Desktop OAuth client). Instead of forcing operators through that GCP setup, ship a simpler workflow: admins mint a CLI bearer token from their existing web session.

### Server
- `POST /api/auth/cli-tokens` (cookie/bearer auth + adminOnly): mints a fresh bearer token, returns it once. Body `{"label":"..."}` optional, defaults to `"cli"`.
- Extracted `App.mintCLIToken` so this handler and the existing `handleCLIExchange` share one implementation of token format/hashing/storage.

### Web UI (admin only)
- New "CLI Access" section in the Settings modal: label input, "Generate token" button, copy-to-clipboard, and a snippet showing the matching `gct auth set-token` invocation. Token is shown once and cleared on modal reopen.

### CLI
- `gct auth set-token <TOKEN> [--server URL]` persists a token to `~/.config/gct/config.json`. Designed for the web-mint workflow.
- `gct --help` AGENT QUICKSTART rewritten: web UI is the recommended path; curl-with-cookie second; `gct login` (device flow) is documented as legacy with its GCP requirements called out.

## Test plan

- [ ] CI green (`go-tests.yml`, `docker-build-pr.yml`, `vitest.yml`)
- [ ] `go test ./...` locally — passes (verified)
- [ ] Open Settings as admin → "CLI Access" appears with the generator
- [ ] Click "Generate token" → token shown, "Copy" copies, snippet is correct
- [ ] Re-open Settings → previously-shown token is hidden
- [ ] Non-admin user → "CLI Access" hidden (UI) and 403 from the API
- [ ] `gct auth set-token <tok> --server URL` → `gct whoami` confirms

## Note on merge

Please use **Merge** (not Squash) per repo convention so the commit history stays linear.