### PR TITLE
feat: batch limit + skip_generation for /api/exercises; idempotent completions (german-conjuctions-trainer-9c9.1)

### DIFF
--- a/internal/app/exercises.go
+++ b/internal/app/exercises.go
@@ -13,6 +13,14 @@ import (
 	"german-conjunctions-trainer/pkg/storage"
 )
 
+const (
+	// maxExerciseBatchLimit is the hard cap on the "limit" field of
+	// POST /api/exercises, so an offline prefetch cannot ask for the world.
+	maxExerciseBatchLimit = 50
+	// maxClientBatchIDLen bounds the client-supplied idempotency key.
+	maxClientBatchIDLen = 64
+)
+
 func (a *App) handleExercises(w http.ResponseWriter, r *http.Request) {
 	requestStartedAt := time.Now()
 	if r.Method != http.MethodPost {
@@ -41,6 +49,15 @@ func (a *App) handleExercises(w http.ResponseWriter, r *http.Request) {
 	}
 
 	userID := getUserIDFromRequest(r)
+
+	// Batch size: default 10, hard cap 50 (offline prefetch asks for more).
+	limit := 10
+	if req.Limit > 0 {
+		limit = req.Limit
+		if limit > maxExerciseBatchLimit {
+			limit = maxExerciseBatchLimit
+		}
+	}
 
 	// Collect all descendant topics
 	descendants, err := a.DB.GetDescendantTopicIDs(req.TopicID)
@@ -98,7 +115,7 @@ func (a *App) handleExercises(w http.ResponseWriter, r *http.Request) {
 		log.Printf("[EXERCISES] Found %d user exercise views for user %s", len(userViews), userID)
 
 		eligibleExercises := getEligibleExercisesForSRS(allExercises, userViews)
-		if len(eligibleExercises) < 10 {
+		if len(eligibleExercises) < 10 && !req.SkipGeneration {
 			// Randomly select a topic from the sub-tree
 			randomTopicID := topicIDs[mrand.Intn(len(topicIDs))]
 			selectedTopic, err := a.DB.GetTopic(randomTopicID)
@@ -144,8 +161,8 @@ func (a *App) handleExercises(w http.ResponseWriter, r *http.Request) {
 			eligibleExercises = getEligibleExercisesForSRS(allExercises, userViews)
 		}
 
-		if len(eligibleExercises) > 10 {
-			finalExercises = eligibleExercises[:10]
+		if len(eligibleExercises) > limit {
+			finalExercises = eligibleExercises[:limit]
 		} else {
 			finalExercises = eligibleExercises
 		}
@@ -206,6 +223,9 @@ func (a *App) handleExercisesComplete(w http.ResponseWriter, r *http.Request) {
 
 	type CompletionRequest struct {
 		Completions []ExerciseCompletion `json:"completions"`
+		// ClientBatchID is an optional idempotency key: the offline queue
+		// retries batches, and a replay must not double-count attempts.
+		ClientBatchID string `json:"client_batch_id"`
 	}
 
 	var req CompletionRequest
@@ -214,10 +234,30 @@ func (a *App) handleExercisesComplete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Printf("[COMPLETION] User %s completing %d exercises", userID, len(req.Completions))
+	if len(req.ClientBatchID) > maxClientBatchIDLen {
+		http.Error(w, "client_batch_id too long", http.StatusBadRequest)
+		return
+	}
+
+	if req.ClientBatchID != "" {
+		claimed, err := a.DB.ClaimCompletionBatch(userID, req.ClientBatchID)
+		if err != nil {
+			log.Printf("ERROR: failed to claim completion batch %s for user %s: %v", req.ClientBatchID, userID, err)
+			http.Error(w, fmt.Sprintf("Failed to claim batch: %v", err), http.StatusInternalServerError)
+			return
+		}
+		if !claimed {
+			log.Printf("[COMPLETION] Replay of batch %s for user %s - ignoring", req.ClientBatchID, userID)
+			writeCompletionSuccess(w)
+			return
+		}
+	}
+
+	log.Printf("[COMPLETION] User %s completing %d exercises (batch %q)", userID, len(req.Completions), req.ClientBatchID)
 
 	userViews, err := a.DB.GetUserExerciseViews(userID)
 	if err != nil {
+		a.releaseCompletionBatch(userID, req.ClientBatchID)
 		http.Error(w, fmt.Sprintf("Failed to get user views: %v", err), http.StatusInternalServerError)
 		return
 	}
@@ -264,14 +304,30 @@ func (a *App) handleExercisesComplete(w http.ResponseWriter, r *http.Request) {
 
 	if err := a.DB.UpdateUserExerciseViews(viewsToUpdate); err != nil {
 		log.Printf("ERROR: failed to update user exercise views: %v", err)
+		a.releaseCompletionBatch(userID, req.ClientBatchID)
 		http.Error(w, fmt.Sprintf("Failed to update views: %v", err), http.StatusInternalServerError)
 		return
 	}
 
 	log.Printf("[COMPLETION] Successfully updated %d exercise completions for user %s", len(viewsToUpdate), userID)
 
+	writeCompletionSuccess(w)
+}
+
+func writeCompletionSuccess(w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{"status": "success"})
+}
+
+// releaseCompletionBatch drops a claim whose work did not land, so the client's
+// retry is applied instead of being swallowed as a replay.
+func (a *App) releaseCompletionBatch(userID, batchID string) {
+	if batchID == "" {
+		return
+	}
+	if err := a.DB.ReleaseCompletionBatch(userID, batchID); err != nil {
+		log.Printf("ERROR: failed to release completion batch %s for user %s: %v", batchID, userID, err)
+	}
 }
 
 func (a *App) handleExerciseFavorite(w http.ResponseWriter, r *http.Request) {

--- a/internal/app/exercises.go
+++ b/internal/app/exercises.go
@@ -239,25 +239,10 @@ func (a *App) handleExercisesComplete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.ClientBatchID != "" {
-		claimed, err := a.DB.ClaimCompletionBatch(userID, req.ClientBatchID)
-		if err != nil {
-			log.Printf("ERROR: failed to claim completion batch %s for user %s: %v", req.ClientBatchID, userID, err)
-			http.Error(w, fmt.Sprintf("Failed to claim batch: %v", err), http.StatusInternalServerError)
-			return
-		}
-		if !claimed {
-			log.Printf("[COMPLETION] Replay of batch %s for user %s - ignoring", req.ClientBatchID, userID)
-			writeCompletionSuccess(w)
-			return
-		}
-	}
-
 	log.Printf("[COMPLETION] User %s completing %d exercises (batch %q)", userID, len(req.Completions), req.ClientBatchID)
 
 	userViews, err := a.DB.GetUserExerciseViews(userID)
 	if err != nil {
-		a.releaseCompletionBatch(userID, req.ClientBatchID)
 		http.Error(w, fmt.Sprintf("Failed to get user views: %v", err), http.StatusInternalServerError)
 		return
 	}
@@ -302,32 +287,22 @@ func (a *App) handleExercisesComplete(w http.ResponseWriter, r *http.Request) {
 		viewsToUpdate = append(viewsToUpdate, view)
 	}
 
-	if err := a.DB.UpdateUserExerciseViews(viewsToUpdate); err != nil {
+	// The batch marker is written in the same transaction as the stats, so a
+	// replayed batch (applied == false) leaves attempts and SRS counters alone.
+	applied, err := a.DB.ApplyCompletionBatch(userID, req.ClientBatchID, viewsToUpdate)
+	if err != nil {
 		log.Printf("ERROR: failed to update user exercise views: %v", err)
-		a.releaseCompletionBatch(userID, req.ClientBatchID)
 		http.Error(w, fmt.Sprintf("Failed to update views: %v", err), http.StatusInternalServerError)
 		return
 	}
+	if !applied {
+		log.Printf("[COMPLETION] Replay of batch %s for user %s - ignored", req.ClientBatchID, userID)
+	} else {
+		log.Printf("[COMPLETION] Successfully updated %d exercise completions for user %s", len(viewsToUpdate), userID)
+	}
 
-	log.Printf("[COMPLETION] Successfully updated %d exercise completions for user %s", len(viewsToUpdate), userID)
-
-	writeCompletionSuccess(w)
-}
-
-func writeCompletionSuccess(w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{"status": "success"})
-}
-
-// releaseCompletionBatch drops a claim whose work did not land, so the client's
-// retry is applied instead of being swallowed as a replay.
-func (a *App) releaseCompletionBatch(userID, batchID string) {
-	if batchID == "" {
-		return
-	}
-	if err := a.DB.ReleaseCompletionBatch(userID, batchID); err != nil {
-		log.Printf("ERROR: failed to release completion batch %s for user %s: %v", batchID, userID, err)
-	}
 }
 
 func (a *App) handleExerciseFavorite(w http.ResponseWriter, r *http.Request) {

--- a/internal/app/exercises_offline_test.go
+++ b/internal/app/exercises_offline_test.go
@@ -1,0 +1,181 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"german-conjunctions-trainer/pkg/llm"
+	"german-conjunctions-trainer/pkg/storage"
+)
+
+// postExercises runs the batch endpoint as an authenticated user and returns
+// the number of exercises in the response.
+func postExercises(t *testing.T, app *App, req llm.GenerateRequest) (int, *httptest.ResponseRecorder) {
+	t.Helper()
+	body, _ := json.Marshal(req)
+	r := httptest.NewRequest("POST", "/api/exercises", bytes.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	r = r.WithContext(context.WithValue(r.Context(), userContextKey, "user1"))
+
+	rr := httptest.NewRecorder()
+	app.handleExercises(rr, r)
+
+	var resp map[string][]map[string]interface{}
+	json.Unmarshal(rr.Body.Bytes(), &resp)
+	return len(resp["exercises"]), rr
+}
+
+func TestExerciseBatchLimit(t *testing.T) {
+	// Any LLM call would hit this dead address and fail the request, so a 200
+	// also proves the cached path was enough.
+	t.Setenv("OPENAI_API_KEY", "dummy-key-for-test")
+	t.Setenv("OPENAI_URL", "http://127.0.0.1:0/invalid")
+
+	app, mock := setupTestAppWithMock(t)
+	topic := &storage.Topic{ID: "t1", Prompt: "my prompt"}
+	mock.topics["t1"] = topic
+	hash := storage.GetPromptHash(topic.Prompt)
+	for i := 0; i < 60; i++ {
+		mock.exercises = append(mock.exercises, &storage.Exercise{
+			ID: fmt.Sprintf("ex%d", i), TopicID: "t1", PromptHash: hash, ExerciseJSON: `{"test":"test"}`,
+		})
+	}
+
+	tests := []struct {
+		name  string
+		limit int
+		want  int
+	}{
+		{"default is 10", 0, 10},
+		{"explicit limit honoured", 25, 25},
+		{"limit above cap clamps to 50", 100, 50},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, rr := postExercises(t, app, llm.GenerateRequest{TopicID: "t1", Limit: tc.limit})
+			if rr.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d. body: %s", rr.Code, rr.Body.String())
+			}
+			if got != tc.want {
+				t.Errorf("limit=%d: expected %d exercises, got %d", tc.limit, tc.want, got)
+			}
+		})
+	}
+}
+
+func TestExerciseSkipGeneration(t *testing.T) {
+	// Without skip_generation this fixture (3 < 10 eligible) would call the
+	// LLM and fail with 502 (see TestExerciseSelection_AutoGenTriggered).
+	t.Setenv("OPENAI_API_KEY", "dummy-key-for-test")
+	t.Setenv("OPENAI_URL", "http://127.0.0.1:0/invalid")
+
+	app, mock := setupTestAppWithMock(t)
+	topic := &storage.Topic{ID: "t1", Prompt: "my prompt"}
+	mock.topics["t1"] = topic
+	hash := storage.GetPromptHash(topic.Prompt)
+	for i := 0; i < 3; i++ {
+		mock.exercises = append(mock.exercises, &storage.Exercise{
+			ID: fmt.Sprintf("ex%d", i), TopicID: "t1", PromptHash: hash, ExerciseJSON: `{"test":"test"}`,
+		})
+	}
+
+	got, rr := postExercises(t, app, llm.GenerateRequest{TopicID: "t1", Limit: 50, SkipGeneration: true})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 (no LLM call), got %d. body: %s", rr.Code, rr.Body.String())
+	}
+	if got != 3 {
+		t.Errorf("expected the 3 cached exercises, got %d", got)
+	}
+}
+
+// postCompletion posts a single completion for the given user and batch ID.
+func postCompletion(t *testing.T, app *App, userID, exerciseID, batchID string, mistakes int) *httptest.ResponseRecorder {
+	t.Helper()
+	body, _ := json.Marshal(map[string]interface{}{
+		"client_batch_id": batchID,
+		"completions": []map[string]interface{}{
+			{"exercise_id": exerciseID, "hints_used": 0, "mistakes": mistakes},
+		},
+	})
+	r := httptest.NewRequest("POST", "/api/exercises/complete", bytes.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	r = r.WithContext(context.WithValue(r.Context(), userContextKey, userID))
+
+	rr := httptest.NewRecorder()
+	app.handleExercisesComplete(rr, r)
+	return rr
+}
+
+func TestCompletionIdempotency(t *testing.T) {
+	app, cleanup := setupIntegrationApp(t)
+	defer cleanup()
+
+	user, err := app.DB.CreateUser("google-offline")
+	if err != nil {
+		t.Fatalf("failed to create user: %v", err)
+	}
+	topic, _ := app.DB.CreateTopic("Topic", "prompt", nil, 0)
+	ex, err := app.DB.CreateExercise(topic.ID, storage.GetPromptHash(topic.Prompt), `{"text":"x"}`, "")
+	if err != nil {
+		t.Fatalf("failed to create exercise: %v", err)
+	}
+
+	// Perfect completion, replayed with the same batch ID.
+	for i := 0; i < 2; i++ {
+		if rr := postCompletion(t, app, user.ID, ex.ID, "batch-1", 0); rr.Code != http.StatusOK {
+			t.Fatalf("attempt %d: expected 200, got %d: %s", i+1, rr.Code, rr.Body.String())
+		}
+	}
+
+	views, err := app.DB.GetUserExerciseViews(user.ID)
+	if err != nil {
+		t.Fatalf("failed to get views: %v", err)
+	}
+	view := views[ex.ID]
+	if view == nil {
+		t.Fatalf("expected a view for exercise %s", ex.ID)
+	}
+	if view.TotalAttempts != 1 {
+		t.Errorf("replayed batch double-counted attempts: got %d, want 1", view.TotalAttempts)
+	}
+	if view.RepetitionCounter != 1 {
+		t.Errorf("replayed batch double-moved the SRS counter: got %d, want 1", view.RepetitionCounter)
+	}
+
+	// A different batch ID is a genuinely new submission and must apply.
+	if rr := postCompletion(t, app, user.ID, ex.ID, "batch-2", 0); rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 for batch-2, got %d: %s", rr.Code, rr.Body.String())
+	}
+	views, _ = app.DB.GetUserExerciseViews(user.ID)
+	if views[ex.ID].TotalAttempts != 2 {
+		t.Errorf("new batch was not applied: TotalAttempts got %d, want 2", views[ex.ID].TotalAttempts)
+	}
+
+	// Without a batch ID behavior is unchanged: every call counts.
+	if rr := postCompletion(t, app, user.ID, ex.ID, "", 0); rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 without batch id, got %d: %s", rr.Code, rr.Body.String())
+	}
+	views, _ = app.DB.GetUserExerciseViews(user.ID)
+	if views[ex.ID].TotalAttempts != 3 {
+		t.Errorf("unbatched completion was not applied: TotalAttempts got %d, want 3", views[ex.ID].TotalAttempts)
+	}
+}
+
+func TestCompletionRejectsOversizedBatchID(t *testing.T) {
+	app, cleanup := setupIntegrationApp(t)
+	defer cleanup()
+
+	long := make([]byte, maxClientBatchIDLen+1)
+	for i := range long {
+		long[i] = 'a'
+	}
+	if rr := postCompletion(t, app, "user1", "ex1", string(long), 0); rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for oversized client_batch_id, got %d", rr.Code)
+	}
+}

--- a/pkg/llm/openai.go
+++ b/pkg/llm/openai.go
@@ -25,8 +25,9 @@ import (
 
 type GenerateRequest struct {
 	TopicID string `json:"topic_id"`
-	// Limit caps how many exercises the batch endpoint returns. 0 means the
-	// default of 10; values above 50 are clamped by the handler.
+	// Limit caps how many exercises the batch endpoint returns to a signed-in
+	// user. 0 means the default of 10; values above 50 are clamped by the
+	// handler. Guests always get the fixed 10.
 	Limit int `json:"limit,omitempty"`
 	// SkipGeneration tells the batch endpoint to serve only what is already
 	// cached instead of calling the LLM to top the batch up. Used by the

--- a/pkg/llm/openai.go
+++ b/pkg/llm/openai.go
@@ -25,6 +25,13 @@ import (
 
 type GenerateRequest struct {
 	TopicID string `json:"topic_id"`
+	// Limit caps how many exercises the batch endpoint returns. 0 means the
+	// default of 10; values above 50 are clamped by the handler.
+	Limit int `json:"limit,omitempty"`
+	// SkipGeneration tells the batch endpoint to serve only what is already
+	// cached instead of calling the LLM to top the batch up. Used by the
+	// offline prefetch, which must never block on the provider.
+	SkipGeneration bool `json:"skip_generation,omitempty"`
 }
 
 type ResponseFormat struct {

--- a/pkg/storage/sqlite.go
+++ b/pkg/storage/sqlite.go
@@ -144,6 +144,13 @@ func (s *SQLiteStorage) runMigrations() error {
 			revoked_at DATETIME
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_cli_tokens_user_id ON cli_tokens(user_id)`,
+		`CREATE TABLE IF NOT EXISTS processed_completion_batches (
+			user_id TEXT NOT NULL,
+			batch_id TEXT NOT NULL,
+			created_at DATETIME NOT NULL,
+			PRIMARY KEY(user_id, batch_id),
+			FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE
+		)`,
 	}
 
 	for _, migration := range migrations {
@@ -1449,6 +1456,31 @@ func (s *SQLiteStorage) GetDatabaseStats(audioCacheDir, dbFilePath string) (*Dat
 	}
 
 	return stats, nil
+}
+
+// ClaimCompletionBatch inserts the (user, batch) pair and reports whether this
+// call inserted it. A false return means the batch was already processed.
+func (s *SQLiteStorage) ClaimCompletionBatch(userID, batchID string) (bool, error) {
+	res, err := s.db.Exec(
+		`INSERT OR IGNORE INTO processed_completion_batches(user_id, batch_id, created_at) VALUES(?, ?, ?)`,
+		userID, batchID, time.Now().UTC(),
+	)
+	if err != nil {
+		return false, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return n > 0, nil
+}
+
+func (s *SQLiteStorage) ReleaseCompletionBatch(userID, batchID string) error {
+	_, err := s.db.Exec(
+		`DELETE FROM processed_completion_batches WHERE user_id = ? AND batch_id = ?`,
+		userID, batchID,
+	)
+	return err
 }
 
 func (s *SQLiteStorage) CreateCLIToken(userID, tokenHash, label string) (*CLIToken, error) {

--- a/pkg/storage/sqlite.go
+++ b/pkg/storage/sqlite.go
@@ -1026,6 +1026,48 @@ func (s *SQLiteStorage) UpdateUserExerciseViews(viewsToUpdate []*UserExerciseVie
 	}
 	defer tx.Rollback()
 
+	if err := upsertUserExerciseViews(tx, viewsToUpdate); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// ApplyCompletionBatch writes the view updates and records batchID in a single
+// transaction, so an idempotency marker can never outlive a failed write.
+// It reports false (and writes nothing) when batchID was already recorded —
+// i.e. the client replayed a batch that has already been applied. An empty
+// batchID skips the marker and always applies.
+func (s *SQLiteStorage) ApplyCompletionBatch(userID, batchID string, viewsToUpdate []*UserExerciseView) (bool, error) {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return false, err
+	}
+	defer tx.Rollback()
+
+	if batchID != "" {
+		res, err := tx.Exec(
+			`INSERT OR IGNORE INTO processed_completion_batches(user_id, batch_id, created_at) VALUES(?, ?, ?)`,
+			userID, batchID, time.Now().UTC(),
+		)
+		if err != nil {
+			return false, err
+		}
+		n, err := res.RowsAffected()
+		if err != nil {
+			return false, err
+		}
+		if n == 0 {
+			return false, nil
+		}
+	}
+
+	if err := upsertUserExerciseViews(tx, viewsToUpdate); err != nil {
+		return false, err
+	}
+	return true, tx.Commit()
+}
+
+func upsertUserExerciseViews(tx *sql.Tx, viewsToUpdate []*UserExerciseView) error {
 	stmt, err := tx.Prepare(`
 		INSERT INTO user_exercise_views(id, user_id, exercise_id, last_viewed, repetition_counter,
 		                                 total_attempts, successful_attempts, failed_attempts, hints_used, mistakes_made, is_favorite)
@@ -1055,8 +1097,7 @@ func (s *SQLiteStorage) UpdateUserExerciseViews(viewsToUpdate []*UserExerciseVie
 			return err
 		}
 	}
-
-	return tx.Commit()
+	return nil
 }
 
 func (s *SQLiteStorage) GetUserByGoogleID(googleID string) (*User, error) {
@@ -1456,31 +1497,6 @@ func (s *SQLiteStorage) GetDatabaseStats(audioCacheDir, dbFilePath string) (*Dat
 	}
 
 	return stats, nil
-}
-
-// ClaimCompletionBatch inserts the (user, batch) pair and reports whether this
-// call inserted it. A false return means the batch was already processed.
-func (s *SQLiteStorage) ClaimCompletionBatch(userID, batchID string) (bool, error) {
-	res, err := s.db.Exec(
-		`INSERT OR IGNORE INTO processed_completion_batches(user_id, batch_id, created_at) VALUES(?, ?, ?)`,
-		userID, batchID, time.Now().UTC(),
-	)
-	if err != nil {
-		return false, err
-	}
-	n, err := res.RowsAffected()
-	if err != nil {
-		return false, err
-	}
-	return n > 0, nil
-}
-
-func (s *SQLiteStorage) ReleaseCompletionBatch(userID, batchID string) error {
-	_, err := s.db.Exec(
-		`DELETE FROM processed_completion_batches WHERE user_id = ? AND batch_id = ?`,
-		userID, batchID,
-	)
-	return err
 }
 
 func (s *SQLiteStorage) CreateCLIToken(userID, tokenHash, label string) (*CLIToken, error) {

--- a/pkg/storage/sqlite_completion_batches_test.go
+++ b/pkg/storage/sqlite_completion_batches_test.go
@@ -3,9 +3,10 @@ package storage
 import (
 	"path/filepath"
 	"testing"
+	"time"
 )
 
-func TestClaimCompletionBatch(t *testing.T) {
+func TestApplyCompletionBatch(t *testing.T) {
 	store, err := NewSQLiteStorage(filepath.Join(t.TempDir(), "batches.db"))
 	if err != nil {
 		t.Fatalf("failed to create sqlite storage: %v", err)
@@ -13,34 +14,49 @@ func TestClaimCompletionBatch(t *testing.T) {
 	t.Cleanup(func() { store.Close() })
 
 	user := mustCreateUser(t, store, "google-batch")
+	other := mustCreateUser(t, store, "google-batch-2")
 
-	claimed, err := store.ClaimCompletionBatch(user.ID, "b1")
-	if err != nil {
-		t.Fatalf("first claim returned error: %v", err)
-	}
-	if !claimed {
-		t.Fatal("first claim should succeed")
+	view := func(userID string, attempts int) []*UserExerciseView {
+		return []*UserExerciseView{{
+			UserID:        userID,
+			ExerciseID:    "ex1",
+			LastViewed:    time.Now().UTC(),
+			TotalAttempts: attempts,
+		}}
 	}
 
-	claimed, err = store.ClaimCompletionBatch(user.ID, "b1")
-	if err != nil {
-		t.Fatalf("replayed claim returned error: %v", err)
+	applied, err := store.ApplyCompletionBatch(user.ID, "b1", view(user.ID, 1))
+	if err != nil || !applied {
+		t.Fatalf("first apply: applied=%v err=%v", applied, err)
 	}
-	if claimed {
-		t.Error("replayed claim should report already-processed")
+
+	// Replay: reports not applied and must not write.
+	applied, err = store.ApplyCompletionBatch(user.ID, "b1", view(user.ID, 99))
+	if err != nil {
+		t.Fatalf("replay returned error: %v", err)
+	}
+	if applied {
+		t.Error("replayed batch should report already-processed")
+	}
+	views, err := store.GetUserExerciseViews(user.ID)
+	if err != nil {
+		t.Fatalf("failed to read views: %v", err)
+	}
+	if views["ex1"].TotalAttempts != 1 {
+		t.Errorf("replay overwrote stats: TotalAttempts got %d, want 1", views["ex1"].TotalAttempts)
 	}
 
 	// Batch IDs are scoped per user.
-	other := mustCreateUser(t, store, "google-batch-2")
-	if claimed, err = store.ClaimCompletionBatch(other.ID, "b1"); err != nil || !claimed {
-		t.Errorf("same batch id for another user should claim: claimed=%v err=%v", claimed, err)
+	if applied, err = store.ApplyCompletionBatch(other.ID, "b1", view(other.ID, 1)); err != nil || !applied {
+		t.Errorf("same batch id for another user should apply: applied=%v err=%v", applied, err)
 	}
 
-	// Releasing lets a retry through again.
-	if err := store.ReleaseCompletionBatch(user.ID, "b1"); err != nil {
-		t.Fatalf("release returned error: %v", err)
+	// No batch ID: always applies.
+	if applied, err = store.ApplyCompletionBatch(user.ID, "", view(user.ID, 2)); err != nil || !applied {
+		t.Errorf("empty batch id should always apply: applied=%v err=%v", applied, err)
 	}
-	if claimed, err = store.ClaimCompletionBatch(user.ID, "b1"); err != nil || !claimed {
-		t.Errorf("claim after release should succeed: claimed=%v err=%v", claimed, err)
+	views, _ = store.GetUserExerciseViews(user.ID)
+	if views["ex1"].TotalAttempts != 2 {
+		t.Errorf("unbatched apply did not write: TotalAttempts got %d, want 2", views["ex1"].TotalAttempts)
 	}
 }

--- a/pkg/storage/sqlite_completion_batches_test.go
+++ b/pkg/storage/sqlite_completion_batches_test.go
@@ -1,0 +1,46 @@
+package storage
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestClaimCompletionBatch(t *testing.T) {
+	store, err := NewSQLiteStorage(filepath.Join(t.TempDir(), "batches.db"))
+	if err != nil {
+		t.Fatalf("failed to create sqlite storage: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	user := mustCreateUser(t, store, "google-batch")
+
+	claimed, err := store.ClaimCompletionBatch(user.ID, "b1")
+	if err != nil {
+		t.Fatalf("first claim returned error: %v", err)
+	}
+	if !claimed {
+		t.Fatal("first claim should succeed")
+	}
+
+	claimed, err = store.ClaimCompletionBatch(user.ID, "b1")
+	if err != nil {
+		t.Fatalf("replayed claim returned error: %v", err)
+	}
+	if claimed {
+		t.Error("replayed claim should report already-processed")
+	}
+
+	// Batch IDs are scoped per user.
+	other := mustCreateUser(t, store, "google-batch-2")
+	if claimed, err = store.ClaimCompletionBatch(other.ID, "b1"); err != nil || !claimed {
+		t.Errorf("same batch id for another user should claim: claimed=%v err=%v", claimed, err)
+	}
+
+	// Releasing lets a retry through again.
+	if err := store.ReleaseCompletionBatch(user.ID, "b1"); err != nil {
+		t.Fatalf("release returned error: %v", err)
+	}
+	if claimed, err = store.ClaimCompletionBatch(user.ID, "b1"); err != nil || !claimed {
+		t.Errorf("claim after release should succeed: claimed=%v err=%v", claimed, err)
+	}
+}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -167,13 +167,11 @@ type Storage interface {
 	ToggleFavorite(userID, exerciseID string) (bool, error)
 	ToggleHideExercise(userID, exerciseID string) (bool, error)
 
-	// Completion idempotency
-	// ClaimCompletionBatch records a client-supplied batch ID for a user and
-	// reports whether this call was the one that recorded it. A false return
-	// means the batch was already processed and must not be applied again.
-	ClaimCompletionBatch(userID, batchID string) (bool, error)
-	// ReleaseCompletionBatch removes a claim whose work failed to apply.
-	ReleaseCompletionBatch(userID, batchID string) error
+	// ApplyCompletionBatch writes view updates and records the client-supplied
+	// batchID atomically. It reports false (writing nothing) when the batch was
+	// already recorded, i.e. the client replayed it. An empty batchID always
+	// applies, matching the pre-idempotency behavior.
+	ApplyCompletionBatch(userID, batchID string, viewsToUpdate []*UserExerciseView) (bool, error)
 
 	// CLI Tokens
 	CreateCLIToken(userID, tokenHash, label string) (*CLIToken, error)

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -167,6 +167,14 @@ type Storage interface {
 	ToggleFavorite(userID, exerciseID string) (bool, error)
 	ToggleHideExercise(userID, exerciseID string) (bool, error)
 
+	// Completion idempotency
+	// ClaimCompletionBatch records a client-supplied batch ID for a user and
+	// reports whether this call was the one that recorded it. A false return
+	// means the batch was already processed and must not be applied again.
+	ClaimCompletionBatch(userID, batchID string) (bool, error)
+	// ReleaseCompletionBatch removes a claim whose work failed to apply.
+	ReleaseCompletionBatch(userID, batchID string) error
+
 	// CLI Tokens
 	CreateCLIToken(userID, tokenHash, label string) (*CLIToken, error)
 	GetCLITokenByHash(tokenHash string) (*CLIToken, error)


### PR DESCRIPTION
Backend half of the offline-prefetch work (bead `german-conjuctions-trainer-9c9.1`). No frontend, `app.go`, `static.go` or `Dockerfile` changes — a parallel PR owns those.

## POST /api/exercises — two optional body fields

- `limit` (int): batch size. Default 10, hard cap 50. It only raises the slice cap on the authenticated SRS path; `getEligibleExercisesForSRS` and its ordering are untouched, and unseen exercises still backfill via the pseudo-overdue 1000 score.
- `skip_generation` (bool): bypasses the synchronous LLM top-up block, so a prefetch never blocks on the provider.

Both live on `llm.GenerateRequest` (already the decode target for this endpoint). Guest path is unchanged — guests still get a fixed 10, as specified.

## POST /api/exercises/complete — `client_batch_id`

Optional string, max 64 chars (longer → 400). New table via the existing `runMigrations` list:

```sql
CREATE TABLE IF NOT EXISTS processed_completion_batches (
  user_id TEXT NOT NULL, batch_id TEXT NOT NULL, created_at DATETIME NOT NULL,
  PRIMARY KEY(user_id, batch_id),
  FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE
)
```

`Storage.ApplyCompletionBatch(userID, batchID, views)` inserts the marker and upserts the views **in one transaction**, returning whether it applied. A replay rolls back and returns 200 with the stats and SRS counters untouched; an empty `client_batch_id` always applies, so existing clients see no change. Response shape is unchanged in every case.

The first draft used a claim-then-apply pair with a release-on-failure path; `codex review` correctly flagged the window where an overlapping retry gets a 200 while the first request fails and releases the claim. The single-transaction version removes that window and is a smaller interface (one method instead of two). `UpdateUserExerciseViews` keeps its signature and now shares the upsert helper.

## Tests

- `internal/app/exercises_offline_test.go`: limit default/explicit/clamp (via table test), `skip_generation` returning cached-only with `OPENAI_URL` pointed at a dead address so any LLM call would fail the request, replay idempotency end-to-end (attempts and repetition counter both move exactly once, a different batch id applies, no batch id applies), oversized batch id → 400.
- `pkg/storage/sqlite_completion_batches_test.go`: apply / replay-is-a-no-op / per-user scoping / empty batch id.

## Verification

- `make vet` — clean.
- `make test` — all packages pass.
- `codex review --base master` — second pass found no issues.
- Frontend tests deliberately not run (CI is the gate; this diff touches no frontend file).

## Deferrals / honest notes

- **Guest path ignores `limit`** — `codex review` raised it; the spec explicitly says the guest branch stays unchanged, so it was left alone. Documented on the `Limit` field.
- **`processed_completion_batches` rows are never pruned.** One small row per batch per user, forever. A retention sweep can be added later if it matters; there is no cleanup job in this PR.
- Concurrent duplicate submissions rely on SQLite serializing the two write transactions; under contention the loser may surface `database is locked` as a 500 and the client retries (then sees the replay path). No new locking was introduced.
