### PR TITLE
feat: offline mode — service worker, offline cache button, stash + completion queue (german-conjuctions-trainer-9c9.2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ COPY --from=builder /app/main .
 
 # Create static directory and copy frontend files
 # These files are also present in the build context.
-COPY index.html app.js privacy.html style.css favicon.svg favicon-32x32.svg ./static/
+COPY index.html app.js privacy.html style.css favicon.svg favicon-32x32.svg sw.js manifest.json ./static/
 COPY js/ ./static/js/
 
 # Make the binary executable and change ownership

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     <link rel="shortcut icon" href="favicon.svg">
     <link rel="apple-touch-icon" href="favicon.svg">
     <meta name="theme-color" content="#A33F11">
+    <link rel="manifest" href="/manifest.json">
     <link href="style.css?v=202604121600" rel="stylesheet">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.5.0/chart.umd.min.js"></script>
     <link href="https://fonts.googleapis.com/css2?family=Nunito+Sans:wght@400;600;700;800&display=swap" rel="stylesheet">
@@ -47,6 +48,11 @@
                     <span class="desktop-only">Logout</span>
                     <span class="mobile-only">👋</span>
                 </button>
+                <button id="offline-cache-btn" class="btn-primary header-btn hidden" title="Download exercises and audio for offline practice">
+                    <span class="desktop-only">Update offline cache</span>
+                    <span class="mobile-only">📥</span>
+                </button>
+                <span id="offline-cache-status" class="hidden text-sm text-white/60"></span>
                 <button id="settings-btn" class="btn-primary header-btn">
                     <span class="desktop-only">Settings</span>
                     <span class="mobile-only">⚙️</span>

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -158,6 +158,8 @@ func (a *App) RegisterRoutes() {
 	http.HandleFunc("/favicon.svg", a.handleFavicon)
 	http.HandleFunc("/favicon-32x32.svg", a.handleFavicon32)
 	http.HandleFunc("/favicon.ico", a.handleFaviconICO)
+	http.HandleFunc("/sw.js", a.handleServiceWorker)
+	http.HandleFunc("/manifest.json", a.handleManifest)
 
 	http.HandleFunc("/api/exercises", a.withOptionalAuth(a.handleExercises))
 	http.HandleFunc("/api/exercises/complete", a.withAuth(a.handleExercisesComplete))

--- a/internal/app/static.go
+++ b/internal/app/static.go
@@ -108,6 +108,36 @@ func (a *App) handleFavicon32(w http.ResponseWriter, r *http.Request) {
 	w.Write(content)
 }
 
+// handleServiceWorker serves sw.js from the root path so the worker's scope
+// covers the whole site. It must not be cached for long: a stale worker keeps
+// serving a stale shell cache.
+func (a *App) handleServiceWorker(w http.ResponseWriter, r *http.Request) {
+	content, err := os.ReadFile(getFilePath("sw.js"))
+	if err != nil {
+		http.Error(w, "File not found", http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/javascript")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Service-Worker-Allowed", "/")
+
+	w.Write(content)
+}
+
+func (a *App) handleManifest(w http.ResponseWriter, r *http.Request) {
+	content, err := os.ReadFile(getFilePath("manifest.json"))
+	if err != nil {
+		http.Error(w, "File not found", http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/manifest+json")
+	w.Header().Set("Cache-Control", "public, max-age=3600")
+
+	w.Write(content)
+}
+
 func (a *App) handleFaviconICO(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, "/favicon.svg", http.StatusMovedPermanently)
 }

--- a/js/__tests__/auth.test.js
+++ b/js/__tests__/auth.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { checkAuthStatus, AUTH_CACHE_KEY } from '../auth.js';
+import { state } from '../state.js';
+import * as api from '../api.js';
+
+vi.mock('../api.js', () => ({
+    checkAuthStatusAPI: vi.fn(),
+    checkIsAdminAPI: vi.fn(),
+    loadUserStatsAPI: vi.fn(async () => ({})),
+    loadExerciseStatsAPI: vi.fn(async () => ({}))
+}));
+
+describe('auth.js offline fallback', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        localStorage.clear();
+        state.isLoggedIn = false;
+        state.userId = null;
+        state.isAdmin = false;
+    });
+
+    it('caches the auth status after a successful check', async () => {
+        api.checkAuthStatusAPI.mockResolvedValueOnce({ logged_in: true, user_id: 'u1' });
+        api.checkIsAdminAPI.mockResolvedValueOnce({ is_admin: true });
+
+        await checkAuthStatus();
+
+        expect(JSON.parse(localStorage.getItem(AUTH_CACHE_KEY))).toEqual({
+            logged_in: true,
+            user_id: 'u1',
+            is_admin: true
+        });
+    });
+
+    it('restores the last known logged-in status when the server is unreachable', async () => {
+        localStorage.setItem(AUTH_CACHE_KEY, JSON.stringify({ logged_in: true, user_id: 'u1', is_admin: false }));
+        api.checkAuthStatusAPI.mockRejectedValueOnce(new Error('Failed to fetch'));
+
+        await checkAuthStatus();
+
+        expect(state.isLoggedIn).toBe(true);
+        expect(state.userId).toBe('u1');
+        expect(state.isAdmin).toBe(false);
+    });
+
+    it('stays logged out when there is nothing cached', async () => {
+        api.checkAuthStatusAPI.mockRejectedValueOnce(new Error('Failed to fetch'));
+
+        await checkAuthStatus();
+
+        expect(state.isLoggedIn).toBe(false);
+        expect(state.isAdmin).toBe(false);
+    });
+});

--- a/js/__tests__/offline.test.js
+++ b/js/__tests__/offline.test.js
@@ -1,0 +1,231 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+    OFFLINE_STASH_KEY,
+    OFFLINE_QUEUE_KEY,
+    flattenExercise,
+    readStash,
+    writeStash,
+    takeStashedExercises,
+    readQueue,
+    enqueueBatch,
+    makeBatch,
+    sendBatch,
+    flushOfflineQueue,
+    updateOfflineCache,
+} from '../offline.js';
+import { state } from '../state.js';
+import * as api from '../api.js';
+
+vi.mock('../api.js', () => ({
+    fetchExercisesFromAPI: vi.fn(),
+    saveUserStatsAPI: vi.fn(),
+    saveExerciseCompletionsAPI: vi.fn(),
+    fetchTTSFilePathAPI: vi.fn(async () => '')
+}));
+
+function setOnline(isOnline) {
+    Object.defineProperty(navigator, 'onLine', { value: isOnline, configurable: true });
+}
+
+function stashRow(id, topicId = 't1') {
+    return { id, topic_id: topicId, correct_german_sentence: `Satz ${id}` };
+}
+
+describe('offline.js', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        localStorage.clear();
+        setOnline(true);
+        state.currentTopicId = 't1';
+        state.recentlyUsedTopics = [];
+        state.isAudioEnabled = false; // keeps preloadExerciseWordAudio a no-op
+        globalThis.fetch = vi.fn(async () => ({ ok: true }));
+    });
+
+    afterEach(() => {
+        setOnline(true);
+    });
+
+    describe('flattenExercise', () => {
+        it('merges exercise_json with the row metadata', () => {
+            const flat = flattenExercise({
+                id: 'ex1',
+                topic_id: 't1',
+                audio_file_path: '/audio_cache/a.mp3',
+                exercise_json: { correct_german_sentence: 'Hallo', scrambled_words: ['Hallo'] }
+            });
+
+            expect(flat).toEqual({
+                correct_german_sentence: 'Hallo',
+                scrambled_words: ['Hallo'],
+                id: 'ex1',
+                audio_file_path: '/audio_cache/a.mp3',
+                is_favorite: false,
+                topic_id: 't1',
+                repetition_counter: 0
+            });
+        });
+    });
+
+    describe('stash', () => {
+        it('round-trips exercises through localStorage', () => {
+            writeStash([stashRow('a'), stashRow('b')], 1234);
+            const stash = readStash();
+            expect(stash.updatedAt).toBe(1234);
+            expect(stash.exercises.map(e => e.id)).toEqual(['a', 'b']);
+        });
+
+        it('returns an empty stash for corrupt storage', () => {
+            localStorage.setItem(OFFLINE_STASH_KEY, 'not json');
+            expect(readStash()).toEqual({ updatedAt: 0, exercises: [] });
+        });
+
+        it('takes exercises for the requested topic and removes them from the stash', () => {
+            writeStash([stashRow('a', 't1'), stashRow('b', 't2'), stashRow('c', 't1')]);
+
+            const taken = takeStashedExercises(10, 't1');
+
+            expect(taken.map(e => e.id)).toEqual(['a', 'c']);
+            expect(readStash().exercises.map(e => e.id)).toEqual(['b']);
+        });
+
+        it('falls back to any topic when the requested topic has nothing stashed', () => {
+            writeStash([stashRow('a', 't2'), stashRow('b', 't3')]);
+
+            const taken = takeStashedExercises(1, 't1');
+
+            expect(taken.map(e => e.id)).toEqual(['a']);
+            expect(readStash().exercises.map(e => e.id)).toEqual(['b']);
+        });
+
+        it('returns nothing when the stash is empty', () => {
+            expect(takeStashedExercises(10, 't1')).toEqual([]);
+        });
+    });
+
+    describe('sendBatch', () => {
+        it('sends stats and completions with the batch id as idempotency key', async () => {
+            const batch = makeBatch({ total_exercises: 2 }, [{ exercise_id: 'ex1', hints_used: 0, mistakes: 0 }]);
+
+            await expect(sendBatch(batch)).resolves.toBe(true);
+
+            expect(api.saveUserStatsAPI).toHaveBeenCalledWith({ total_exercises: 2 });
+            expect(api.saveExerciseCompletionsAPI).toHaveBeenCalledWith(batch.completions, batch.id);
+            expect(batch.id).toBeTruthy();
+        });
+
+        it('keeps the stats payload when the stats POST fails', async () => {
+            api.saveUserStatsAPI.mockRejectedValueOnce(new Error('offline'));
+            const batch = makeBatch({ total_exercises: 1 }, []);
+
+            await expect(sendBatch(batch)).resolves.toBe(false);
+
+            expect(batch.stats).toEqual({ total_exercises: 1 });
+            expect(api.saveExerciseCompletionsAPI).not.toHaveBeenCalled();
+        });
+
+        it('clears the already-delivered stats so a retry cannot double-count them', async () => {
+            api.saveExerciseCompletionsAPI.mockRejectedValueOnce(new Error('offline'));
+            const batch = makeBatch({ total_exercises: 1 }, [{ exercise_id: 'ex1', hints_used: 0, mistakes: 0 }]);
+
+            await expect(sendBatch(batch)).resolves.toBe(false);
+
+            expect(batch.stats).toBeNull();
+            expect(batch.completions).toHaveLength(1);
+        });
+    });
+
+    describe('queue', () => {
+        it('appends batches and drains them on flush', async () => {
+            const batch = makeBatch({ total_exercises: 1 }, [{ exercise_id: 'ex1', hints_used: 0, mistakes: 0 }]);
+            enqueueBatch(batch);
+            expect(readQueue()).toHaveLength(1);
+
+            await flushOfflineQueue();
+
+            expect(api.saveUserStatsAPI).toHaveBeenCalledTimes(1);
+            expect(api.saveExerciseCompletionsAPI).toHaveBeenCalledWith(batch.completions, batch.id);
+            expect(readQueue()).toHaveLength(0);
+        });
+
+        it('keeps batches queued when the send fails', async () => {
+            api.saveUserStatsAPI.mockRejectedValueOnce(new Error('offline'));
+            enqueueBatch(makeBatch({ total_exercises: 1 }, []));
+
+            await flushOfflineQueue();
+
+            expect(readQueue()).toHaveLength(1);
+        });
+
+        it('reuses the same client_batch_id across retries', async () => {
+            api.saveExerciseCompletionsAPI.mockRejectedValueOnce(new Error('offline'));
+            const batch = makeBatch(null, [{ exercise_id: 'ex1', hints_used: 0, mistakes: 0 }]);
+            enqueueBatch(batch);
+
+            await flushOfflineQueue();
+            expect(readQueue()).toHaveLength(1);
+
+            await flushOfflineQueue();
+
+            expect(readQueue()).toHaveLength(0);
+            const ids = api.saveExerciseCompletionsAPI.mock.calls.map(call => call[1]);
+            expect(ids).toEqual([batch.id, batch.id]);
+        });
+
+        it('does nothing while offline', async () => {
+            setOnline(false);
+            enqueueBatch(makeBatch({ total_exercises: 1 }, []));
+
+            await flushOfflineQueue();
+
+            expect(api.saveUserStatsAPI).not.toHaveBeenCalled();
+            expect(readQueue()).toHaveLength(1);
+        });
+
+        it('ignores corrupt queue storage', () => {
+            localStorage.setItem(OFFLINE_QUEUE_KEY, '{oops');
+            expect(readQueue()).toEqual([]);
+        });
+    });
+
+    describe('updateOfflineCache', () => {
+        const row = (id, topicId) => ({ id, topic_id: topicId, audio_file_path: '', exercise_json: {} });
+
+        it('stashes the selected topic plus recent topics, deduped by id', async () => {
+            state.recentlyUsedTopics = [{ id: 't1', name: 'One' }, { id: 't2', name: 'Two' }];
+            api.fetchExercisesFromAPI
+                .mockResolvedValueOnce({ exercises: [row('a', 't1'), row('b', 't1')] })
+                .mockResolvedValueOnce({ exercises: [row('b', 't1'), row('c', 't2')] });
+
+            await updateOfflineCache();
+
+            expect(api.fetchExercisesFromAPI).toHaveBeenNthCalledWith(1, 't1', {});
+            expect(api.fetchExercisesFromAPI).toHaveBeenNthCalledWith(2, 't2', { limit: 25, skip_generation: true });
+            expect(readStash().exercises.map(e => e.id)).toEqual(['a', 'b', 'c']);
+        });
+
+        it('replaces the stash on a second run and survives a failing topic', async () => {
+            api.fetchExercisesFromAPI.mockResolvedValueOnce({ exercises: [row('a', 't1')] });
+            await updateOfflineCache();
+            expect(readStash().exercises.map(e => e.id)).toEqual(['a']);
+
+            api.fetchExercisesFromAPI.mockResolvedValueOnce({ exercises: [row('z', 't1')] });
+            await updateOfflineCache();
+            expect(readStash().exercises.map(e => e.id)).toEqual(['z']);
+
+            api.fetchExercisesFromAPI.mockRejectedValueOnce(new Error('boom'));
+            await expect(updateOfflineCache()).resolves.toBeUndefined();
+            expect(readStash().exercises).toEqual([]);
+        });
+
+        it('flushes queued results before fetching', async () => {
+            enqueueBatch(makeBatch({ total_exercises: 1 }, []));
+            api.fetchExercisesFromAPI.mockResolvedValueOnce({ exercises: [] });
+
+            await updateOfflineCache();
+
+            expect(api.saveUserStatsAPI).toHaveBeenCalledTimes(1);
+            expect(readQueue()).toHaveLength(0);
+        });
+    });
+});

--- a/js/__tests__/session.test.js
+++ b/js/__tests__/session.test.js
@@ -3,11 +3,14 @@ import { fetchExercises, saveUserStats } from '../session.js';
 import { state } from '../state.js';
 import { dom } from '../dom.js';
 import * as api from '../api.js';
+import { OFFLINE_STASH_KEY, readQueue } from '../offline.js';
 
 vi.mock('../api.js', () => ({
     fetchExercisesFromAPI: vi.fn(),
     saveUserStatsAPI: vi.fn(),
-    saveExerciseCompletionsAPI: vi.fn()
+    saveExerciseCompletionsAPI: vi.fn(),
+    // session.js -> offline.js -> audio.js needs this export to exist
+    fetchTTSFilePathAPI: vi.fn()
 }));
 
 // Mock exercise methods called by fetchExercises
@@ -44,6 +47,8 @@ describe('session.js', () => {
         dom.timer.textContent = '';
 
         globalThis.alert.mockClear();
+        localStorage.clear();
+        Object.defineProperty(navigator, 'onLine', { value: true, configurable: true });
         vi.useFakeTimers();
     });
 
@@ -133,6 +138,52 @@ describe('session.js', () => {
         });
     });
 
+    describe('offline fallback', () => {
+        const stashOne = () => localStorage.setItem(OFFLINE_STASH_KEY, JSON.stringify({
+            updatedAt: 1,
+            exercises: [{ id: 'stashed1', topic_id: 't1', correct_german_sentence: 'Hallo Welt' }]
+        }));
+
+        it('serves stashed exercises when the network fetch fails', async () => {
+            stashOne();
+            api.fetchExercisesFromAPI.mockRejectedValueOnce(new Error('Failed to fetch'));
+
+            await fetchExercises();
+
+            expect(state.exercises.map(e => e.id)).toEqual(['stashed1']);
+            expect(globalThis.alert).not.toHaveBeenCalled();
+            // Served exercises are consumed from the stash
+            expect(JSON.parse(localStorage.getItem(OFFLINE_STASH_KEY)).exercises).toEqual([]);
+        });
+
+        it('skips the network entirely when navigator reports offline', async () => {
+            stashOne();
+            Object.defineProperty(navigator, 'onLine', { value: false, configurable: true });
+
+            await fetchExercises();
+
+            expect(api.fetchExercisesFromAPI).not.toHaveBeenCalled();
+            expect(state.exercises.map(e => e.id)).toEqual(['stashed1']);
+        });
+
+        it('alerts with an offline-specific message when the stash is empty', async () => {
+            Object.defineProperty(navigator, 'onLine', { value: false, configurable: true });
+
+            await fetchExercises();
+
+            expect(globalThis.alert).toHaveBeenCalledWith(expect.stringContaining('no exercises are cached'));
+        });
+
+        it('still reports the original error when online and the stash is empty', async () => {
+            const error = new Error('Generic error');
+            api.fetchExercisesFromAPI.mockRejectedValueOnce(error);
+
+            await fetchExercises();
+
+            expect(globalThis.alert).toHaveBeenCalledWith(expect.stringContaining('Failed to fetch new exercises'));
+        });
+    });
+
     describe('saveUserStats', () => {
         it('saves general stats and individual completion stats', async () => {
             state.exercises = [{}, {}];
@@ -158,7 +209,22 @@ describe('session.js', () => {
             expect(api.saveExerciseCompletionsAPI).toHaveBeenCalledWith([
                 { exercise_id: 'ex1', hints_used: 1, mistakes: 0 },
                 { exercise_id: 'ex2', hints_used: 0, mistakes: 2 }
-            ]);
+            ], expect.any(String));
+        });
+
+        it('queues the session results instead of dropping them when the POST fails', async () => {
+            state.exercises = [{}];
+            state.completedExerciseIds.add('ex1');
+            state.exercisePerformance.set('ex1', { hints: 0, mistakes: 1 });
+            api.saveUserStatsAPI.mockRejectedValueOnce(new Error('offline'));
+
+            await saveUserStats();
+
+            const queue = readQueue();
+            expect(queue).toHaveLength(1);
+            expect(queue[0].id).toBeTruthy();
+            expect(queue[0].stats.total_exercises).toBe(1);
+            expect(queue[0].completions).toEqual([{ exercise_id: 'ex1', hints_used: 0, mistakes: 1 }]);
         });
     });
 });

--- a/js/__tests__/setup.js
+++ b/js/__tests__/setup.js
@@ -109,6 +109,16 @@ vi.mock('../dom.js', () => {
       historySortErrors: createMockElement('button'),
       historySortDate: createMockElement('button'),
 
+      // Auth / header DOM
+      loginBtn: createMockElement('button'),
+      logoutBtn: createMockElement('button'),
+      historyBtn: createMockElement('button'),
+      settingsBtn: createMockElement('button'),
+      skipRemoveBtn: createMockElement('button'),
+      offlineCacheBtn: createMockElement('button'),
+      offlineCacheStatus: createMockElement('span'),
+      topicSearch: createMockElement('input'),
+
       // Additional elements can be added here as needed by tests
       constructedSentenceEl: createMockElement('div'),
       answerPrompt: createMockElement('div'),

--- a/js/__tests__/topics.test.js
+++ b/js/__tests__/topics.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { loadTopics, TOPICS_CACHE_KEY } from '../topics.js';
+import { state } from '../state.js';
+import * as api from '../api.js';
+
+vi.mock('../api.js', () => ({
+    fetchTopicsAPI: vi.fn(),
+    createTopicAPI: vi.fn(),
+    deleteTopicAPI: vi.fn(),
+    updateTopicAPI: vi.fn(),
+    moveTopicAPI: vi.fn(),
+    fetchVersionsAPI: vi.fn(),
+    restoreVersionAPI: vi.fn(),
+    fetchLastGenerationDebugAPI: vi.fn(),
+    fetchLastRefinedPromptAPI: vi.fn(),
+    saveUserSettingsAPI: vi.fn()
+}));
+
+const payload = { topics: [{ id: 't1', name: 'Weil', parent_id: null }] };
+
+describe('topics.js offline fallback', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        localStorage.clear();
+        state.topics = [];
+        globalThis.alert.mockClear();
+    });
+
+    it('caches the topics payload after a successful load', async () => {
+        api.fetchTopicsAPI.mockResolvedValueOnce(payload);
+
+        await loadTopics();
+
+        expect(state.topics).toHaveLength(1);
+        expect(JSON.parse(localStorage.getItem(TOPICS_CACHE_KEY))).toEqual(payload);
+    });
+
+    it('falls back to the cached payload when the request fails', async () => {
+        localStorage.setItem(TOPICS_CACHE_KEY, JSON.stringify(payload));
+        api.fetchTopicsAPI.mockRejectedValueOnce(new Error('Failed to fetch'));
+
+        await loadTopics();
+
+        expect(state.topics.map(t => t.id)).toEqual(['t1']);
+        expect(globalThis.alert).not.toHaveBeenCalled();
+    });
+
+    it('alerts only when there is no cached payload', async () => {
+        api.fetchTopicsAPI.mockRejectedValueOnce(new Error('Failed to fetch'));
+
+        await loadTopics();
+
+        expect(globalThis.alert).toHaveBeenCalledWith(expect.stringContaining('Failed to load topics'));
+    });
+});

--- a/js/api.js
+++ b/js/api.js
@@ -117,11 +117,13 @@ export async function moveTopicAPI(topicId, parentId, position = null) {
     return response.json();
 }
 
-export async function fetchExercisesFromAPI(topicId) {
+// options may carry { limit, skip_generation } for offline pre-caching.
+// Older servers ignore unknown JSON fields, so sending them is always safe.
+export async function fetchExercisesFromAPI(topicId, options = {}) {
     const response = await apiFetch('/api/exercises', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ topic_id: topicId })
+        body: JSON.stringify({ topic_id: topicId, ...options })
     });
     return response.json();
 }
@@ -163,21 +165,29 @@ export async function toggleHideExerciseAPI(exerciseId) {
     return response.json();
 }
 
+// Both save* helpers throw on a non-2xx response so the caller can queue the
+// payload for a later retry instead of silently dropping the session results.
 export async function saveUserStatsAPI(data) {
-    await fetch('/api/user/stats', {
+    const response = await fetch('/api/user/stats', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(data)
     });
+    if (!response.ok) throw Object.assign(new Error('Failed to save user stats'), { status: response.status });
 }
 
-export async function saveExerciseCompletionsAPI(completions) {
+// clientBatchId is an idempotency key: the server dedupes replays of the same
+// batch, which makes retrying a queued offline batch safe.
+export async function saveExerciseCompletionsAPI(completions, clientBatchId) {
     if (completions.length === 0) return;
-    await fetch('/api/exercises/complete', {
+    const payload = { completions };
+    if (clientBatchId) payload.client_batch_id = clientBatchId;
+    const response = await fetch('/api/exercises/complete', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ completions })
+        body: JSON.stringify(payload)
     });
+    if (!response.ok) throw Object.assign(new Error('Failed to save exercise completions'), { status: response.status });
     console.log('Saved completion data for', completions.length, 'exercises');
 }
 

--- a/js/audio.js
+++ b/js/audio.js
@@ -1,4 +1,4 @@
-import { state } from './state.js';
+import { state, showLocalStorageError } from './state.js';
 import { dom } from './dom.js';
 import { fetchTTSFilePathAPI } from './api.js';
 
@@ -6,15 +6,6 @@ const AUDIO_ENABLED_STORAGE_KEY = 'audioEnabled';
 const WORD_AUDIO_CACHE_STORAGE_KEY = 'wordAudioCacheV1';
 const MAX_WORD_AUDIO_CACHE_ENTRIES = 2000;
 const WORD_AUDIO_PRELOAD_CONCURRENCY = 3;
-
-let localStorageErrorShown = false; // Prevent multiple notifications for localStorage errors
-
-function _showLocalStorageError(context) {
-    if (!localStorageErrorShown) {
-        localStorageErrorShown = true;
-        alert(`Warning: Unable to save your preferences to local storage. Your changes may not persist after closing the browser.\n\nContext: ${context}`);
-    }
-}
 
 export function isPunctuation(token) {
     return /^[^\p{L}\p{N}]+$/u.test(token);
@@ -197,15 +188,18 @@ export async function playWordAudio(word) {
     await playAudioFile(generatedFilePath);
 }
 
+// Returns a promise that settles when preloading finishes; callers that just
+// want fire-and-forget (renderExercise) can ignore it, the offline cache
+// warm-up awaits it to keep TTS load sequential across exercises.
 export function preloadExerciseWordAudio(exercise) {
-    if (!state.isAudioEnabled) return;
-    if (!exercise || !exercise.correct_german_sentence) return;
+    if (!state.isAudioEnabled) return Promise.resolve();
+    if (!exercise || !exercise.correct_german_sentence) return Promise.resolve();
 
     const allTokens = exercise.correct_german_sentence.match(/[\p{L}\p{N}']+|[^\s\p{L}\p{N}]/gu) || [];
     const uniqueWords = [...new Set(allTokens.filter(token => !isPunctuation(token)).map(w => w.trim()))].filter(Boolean);
     const wordsToPreload = uniqueWords.filter(word => !peekWordAudioPathFromCache(word));
 
-    if (wordsToPreload.length === 0) return;
+    if (wordsToPreload.length === 0) return Promise.resolve();
 
     let currentIndex = 0;
     const workerCount = Math.min(WORD_AUDIO_PRELOAD_CONCURRENCY, wordsToPreload.length);
@@ -216,9 +210,8 @@ export function preloadExerciseWordAudio(exercise) {
         }
     });
 
-    Promise.allSettled(workers).catch(() => {
-        // Ignore preload errors; on-demand playback remains available.
-    });
+    // Ignore preload errors; on-demand playback remains available.
+    return Promise.allSettled(workers).catch(() => {});
 }
 
 export function updateAudioToggleUI() {
@@ -246,7 +239,7 @@ export function setAudioEnabled(isEnabled) {
         localStorage.setItem(AUDIO_ENABLED_STORAGE_KEY, String(state.isAudioEnabled));
     } catch (error) {
         console.error('Failed to save audio enabled state:', error);
-        _showLocalStorageError('audio preferences');
+        showLocalStorageError('audio preferences');
     }
 
     if (!state.isAudioEnabled && state.activeAudio) {

--- a/js/auth.js
+++ b/js/auth.js
@@ -2,6 +2,32 @@ import { state } from './state.js';
 import { dom } from './dom.js';
 import { checkAuthStatusAPI, checkIsAdminAPI, loadUserStatsAPI, loadExerciseStatsAPI } from './api.js';
 
+export const AUTH_CACHE_KEY = 'authStatusV1';
+
+function cacheAuthStatus() {
+    try {
+        localStorage.setItem(AUTH_CACHE_KEY, JSON.stringify({
+            logged_in: state.isLoggedIn,
+            user_id: state.userId,
+            is_admin: state.isAdmin,
+        }));
+    } catch (error) {
+        console.error('Failed to cache auth status:', error);
+    }
+}
+
+function readCachedAuthStatus() {
+    try {
+        const raw = localStorage.getItem(AUTH_CACHE_KEY);
+        if (!raw) return null;
+        const parsed = JSON.parse(raw);
+        return parsed && typeof parsed === 'object' ? parsed : null;
+    } catch (error) {
+        console.error('Failed to read cached auth status:', error);
+        return null;
+    }
+}
+
 export async function checkAuthStatus() {
     try {
         const data = await checkAuthStatusAPI();
@@ -15,10 +41,16 @@ export async function checkAuthStatus() {
         } else {
             state.isAdmin = false;
         }
+        cacheAuthStatus();
         updateAuthUI();
     } catch (error) {
         console.error('Error checking auth status:', error);
-        state.isAdmin = false;
+        // Unreachable server (typically offline): trust the last known status
+        // so the logged-in UI — including offline practice — stays available.
+        const cached = readCachedAuthStatus();
+        state.isLoggedIn = Boolean(cached?.logged_in);
+        state.userId = cached?.user_id ?? null;
+        state.isAdmin = Boolean(cached?.is_admin);
         updateAuthUI();
     }
 }
@@ -45,11 +77,13 @@ export function updateAuthUI() {
         dom.logoutBtn.classList.remove('hidden');
         dom.historyBtn.classList.remove('hidden');
         dom.skipRemoveBtn.classList.remove('hidden');
+        dom.offlineCacheBtn?.classList.remove('hidden');
     } else {
         dom.loginBtn.classList.remove('hidden');
         dom.logoutBtn.classList.add('hidden');
         dom.historyBtn.classList.add('hidden');
         dom.skipRemoveBtn.classList.add('hidden');
+        dom.offlineCacheBtn?.classList.add('hidden');
     }
 
     if (state.isAdmin) {

--- a/js/dom.js
+++ b/js/dom.js
@@ -77,6 +77,8 @@ export const dom = {
     loginBtn: document.getElementById('login-btn'),
     logoutBtn: document.getElementById('logout-btn'),
     historyBtn: document.getElementById('history-btn'),
+    offlineCacheBtn: document.getElementById('offline-cache-btn'),
+    offlineCacheStatus: document.getElementById('offline-cache-status'),
     replayAudioBtn: document.getElementById('replay-audio-btn'),
     nextExerciseBtn: document.getElementById('next-exercise-btn'),
     toggleFavoriteBtn: document.getElementById('toggle-favorite-btn'),

--- a/js/main.js
+++ b/js/main.js
@@ -55,6 +55,7 @@ import {
     checkAuthStatus,
 } from './auth.js';
 import { fetchDatabaseStatsAPI, createCLITokenAPI } from './api.js';
+import { updateOfflineCache, flushOfflineQueue, renderOfflineCacheStatus } from './offline.js';
 import {
     showExerciseHistory,
     renderHistoryPage,
@@ -353,6 +354,14 @@ dom.logoutBtn.addEventListener('click', () => {
     window.location.href = '/auth/logout';
 });
 
+// Offline cache (logged-in users only; visibility handled by updateAuthUI)
+if (dom.offlineCacheBtn) {
+    dom.offlineCacheBtn.addEventListener('click', updateOfflineCache);
+}
+
+// Retry queued session results as soon as connectivity is back.
+window.addEventListener('online', () => { flushOfflineQueue(); });
+
 // History
 dom.historyBtn.addEventListener('click', showExerciseHistory);
 
@@ -491,6 +500,16 @@ function init() {
     updateAudioToggleUI();
     checkAuthStatus();
     loadTopics();
+
+    // Service worker: caches the app shell + audio so sessions work offline.
+    if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.register('/sw.js').catch((error) => {
+            console.error('Service worker registration failed:', error);
+        });
+    }
+
+    renderOfflineCacheStatus();
+    flushOfflineQueue();
 
     // Start with sample exercises for testing
     state.exercises = sampleExercises.exercises;

--- a/js/offline.js
+++ b/js/offline.js
@@ -1,0 +1,257 @@
+// Offline support: exercise stash, completion queue and the
+// "Update offline cache" flow. Storage is plain localStorage (same pattern as
+// state.js) — every read is try/catch-wrapped with a safe fallback.
+import { state, showLocalStorageError } from './state.js';
+import { dom } from './dom.js';
+import { fetchExercisesFromAPI, saveUserStatsAPI, saveExerciseCompletionsAPI } from './api.js';
+import { preloadExerciseWordAudio } from './audio.js';
+
+export const OFFLINE_STASH_KEY = 'offlineStashV1';
+export const OFFLINE_QUEUE_KEY = 'offlineQueueV1';
+
+const MAX_STASHED_EXERCISES = 100;
+const PER_TOPIC_STASH_LIMIT = 25;
+
+// Server-side session size (internal/app/exercises.go returns at most 10).
+export const SESSION_SIZE = 10;
+
+function newBatchId() {
+    // crypto.randomUUID needs a secure context; fall back to a good-enough id.
+    if (globalThis.crypto && typeof globalThis.crypto.randomUUID === 'function') {
+        return globalThis.crypto.randomUUID();
+    }
+    return `b-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+// flattenExercise turns an /api/exercises row into the shape the exercise
+// renderer expects. Shared by the live fetch path and the offline stash so
+// both produce identical objects.
+export function flattenExercise(row) {
+    return {
+        ...row.exercise_json,
+        id: row.id,
+        audio_file_path: row.audio_file_path,
+        is_favorite: row.is_favorite || false,
+        topic_id: row.topic_id,
+        repetition_counter: row.repetition_counter || 0,
+    };
+}
+
+// --- Stash -----------------------------------------------------------------
+
+export function readStash() {
+    try {
+        const raw = localStorage.getItem(OFFLINE_STASH_KEY);
+        if (!raw) return { updatedAt: 0, exercises: [] };
+        const parsed = JSON.parse(raw);
+        if (!parsed || !Array.isArray(parsed.exercises)) return { updatedAt: 0, exercises: [] };
+        return {
+            updatedAt: Number.isFinite(parsed.updatedAt) ? parsed.updatedAt : 0,
+            exercises: parsed.exercises.filter((ex) => ex && typeof ex === 'object'),
+        };
+    } catch (error) {
+        console.error('Failed to read offline stash:', error);
+        return { updatedAt: 0, exercises: [] };
+    }
+}
+
+export function writeStash(exercises, updatedAt = Date.now()) {
+    try {
+        localStorage.setItem(OFFLINE_STASH_KEY, JSON.stringify({ updatedAt, exercises }));
+        return true;
+    } catch (error) {
+        console.error('Failed to write offline stash:', error);
+        showLocalStorageError('offline exercise cache');
+        return false;
+    }
+}
+
+// takeStashedExercises pops up to `count` exercises off the stash, preferring
+// the requested topic, and persists the remainder.
+export function takeStashedExercises(count = SESSION_SIZE, topicId = '') {
+    const stash = readStash();
+    if (stash.exercises.length === 0) return [];
+
+    const preferred = topicId ? stash.exercises.filter((ex) => ex.topic_id === topicId) : [];
+    const pool = preferred.length > 0 ? preferred : stash.exercises;
+    const taken = pool.slice(0, count);
+    const takenIds = new Set(taken.map((ex) => ex.id));
+
+    writeStash(stash.exercises.filter((ex) => !takenIds.has(ex.id)), stash.updatedAt);
+    return taken;
+}
+
+// --- Completion queue ------------------------------------------------------
+
+export function readQueue() {
+    try {
+        const raw = localStorage.getItem(OFFLINE_QUEUE_KEY);
+        if (!raw) return [];
+        const parsed = JSON.parse(raw);
+        return Array.isArray(parsed) ? parsed.filter((b) => b && typeof b === 'object' && b.id) : [];
+    } catch (error) {
+        console.error('Failed to read offline queue:', error);
+        return [];
+    }
+}
+
+function writeQueue(batches) {
+    try {
+        localStorage.setItem(OFFLINE_QUEUE_KEY, JSON.stringify(batches));
+    } catch (error) {
+        console.error('Failed to write offline queue:', error);
+        showLocalStorageError('offline results queue');
+    }
+}
+
+export function enqueueBatch(batch) {
+    const queue = readQueue();
+    queue.push(batch);
+    writeQueue(queue);
+}
+
+export function makeBatch(stats, completions) {
+    return { id: newBatchId(), stats: stats || null, completions: completions || [] };
+}
+
+// sendBatch posts a batch's payloads. On partial success it clears the part
+// that landed (so a retry can't double-count the stats aggregate) and returns
+// false. Returns true only when the whole batch is delivered.
+export async function sendBatch(batch) {
+    if (batch.stats) {
+        try {
+            await saveUserStatsAPI(batch.stats);
+            batch.stats = null;
+        } catch (error) {
+            console.error('Failed to save user stats:', error);
+            return false;
+        }
+    }
+
+    if (batch.completions && batch.completions.length > 0) {
+        try {
+            // client_batch_id lets the server dedupe replays of this batch.
+            await saveExerciseCompletionsAPI(batch.completions, batch.id);
+        } catch (error) {
+            console.error('Failed to save exercise completions:', error);
+            return false;
+        }
+    }
+
+    return true;
+}
+
+// flushOfflineQueue drains queued batches. Entries are removed only on a
+// fully successful send; anything else stays for the next attempt.
+let flushInFlight = null;
+
+export async function flushOfflineQueue() {
+    if (navigator.onLine === false) return;
+    // init() and the "online" event can fire together; overlapping flushes
+    // would send the same batch twice.
+    if (flushInFlight) return flushInFlight;
+    flushInFlight = drainQueue().finally(() => { flushInFlight = null; });
+    return flushInFlight;
+}
+
+async function drainQueue() {
+    const queue = readQueue();
+    if (queue.length === 0) return;
+
+    const remaining = [];
+    let stopped = false;
+    for (const batch of queue) {
+        if (stopped) {
+            remaining.push(batch);
+            continue;
+        }
+        const ok = await sendBatch(batch);
+        if (!ok) {
+            remaining.push(batch);
+            stopped = true; // still offline / server unhappy — don't hammer it
+        }
+    }
+    writeQueue(remaining);
+}
+
+// --- "Update offline cache" flow -------------------------------------------
+
+function setStatus(text) {
+    if (!dom.offlineCacheStatus) return;
+    dom.offlineCacheStatus.textContent = text;
+    dom.offlineCacheStatus.classList.toggle('hidden', !text);
+}
+
+// renderOfflineCacheStatus shows the stored stash summary (count + timestamp).
+export function renderOfflineCacheStatus() {
+    const stash = readStash();
+    if (stash.exercises.length === 0 || !stash.updatedAt) {
+        setStatus('');
+        return;
+    }
+    setStatus(`${stash.exercises.length} offline · ${new Date(stash.updatedAt).toLocaleString()}`);
+}
+
+async function fetchForStash(topicId, extraOptions) {
+    try {
+        const data = await fetchExercisesFromAPI(topicId, extraOptions);
+        return (data.exercises || []).map(flattenExercise);
+    } catch (error) {
+        console.error('Offline cache: failed to fetch exercises for topic', topicId, error);
+        return [];
+    }
+}
+
+export async function updateOfflineCache() {
+    if (dom.offlineCacheBtn) dom.offlineCacheBtn.disabled = true;
+
+    try {
+        setStatus('Syncing results…');
+        await flushOfflineQueue();
+
+        setStatus('Fetching exercises…');
+        const byId = new Map();
+
+        if (state.currentTopicId) {
+            for (const ex of await fetchForStash(state.currentTopicId, {})) {
+                byId.set(ex.id, ex);
+            }
+        }
+
+        for (const topic of state.recentlyUsedTopics) {
+            if (byId.size >= MAX_STASHED_EXERCISES) break;
+            if (topic.id === state.currentTopicId) continue;
+            const fetched = await fetchForStash(topic.id, { limit: PER_TOPIC_STASH_LIMIT, skip_generation: true });
+            for (const ex of fetched) {
+                byId.set(ex.id, ex);
+            }
+        }
+
+        const exercises = [...byId.values()].slice(0, MAX_STASHED_EXERCISES);
+        writeStash(exercises);
+
+        // Warm audio: the sentence file goes straight into the SW cache, the
+        // per-word files land in wordAudioCacheV1 + SW cache via TTS.
+        let done = 0;
+        for (const exercise of exercises) {
+            if (exercise.audio_file_path) {
+                try {
+                    await fetch(exercise.audio_file_path);
+                } catch (error) {
+                    // Best effort — a missing audio file never aborts the run.
+                }
+            }
+            try {
+                await preloadExerciseWordAudio(exercise);
+            } catch (error) {
+                // Same: per-word TTS failures are non-fatal.
+            }
+            done++;
+            setStatus(`${done}/${exercises.length}…`);
+        }
+
+        renderOfflineCacheStatus();
+    } finally {
+        if (dom.offlineCacheBtn) dom.offlineCacheBtn.disabled = false;
+    }
+}

--- a/js/offline.js
+++ b/js/offline.js
@@ -131,6 +131,9 @@ export async function sendBatch(batch) {
     if (batch.completions && batch.completions.length > 0) {
         try {
             // client_batch_id lets the server dedupe replays of this batch.
+            // Dedupe lands with the parallel backend PR; until then a retry
+            // after a lost response can double-count that batch (which is
+            // still strictly better than today's silent data loss).
             await saveExerciseCompletionsAPI(batch.completions, batch.id);
         } catch (error) {
             console.error('Failed to save exercise completions:', error);
@@ -218,6 +221,10 @@ export async function updateOfflineCache() {
             }
         }
 
+        // limit + skip_generation are honoured by the /api/exercises change
+        // shipping in a parallel backend PR. Until that lands the server
+        // ignores them (unknown JSON fields), so a warm-up of a thin topic can
+        // still trigger generation — correct, just slower and more expensive.
         for (const topic of state.recentlyUsedTopics) {
             if (byId.size >= MAX_STASHED_EXERCISES) break;
             if (topic.id === state.currentTopicId) continue;

--- a/js/session.js
+++ b/js/session.js
@@ -1,7 +1,8 @@
 import { state } from './state.js';
 import { dom } from './dom.js';
-import { fetchExercisesFromAPI, saveUserStatsAPI, saveExerciseCompletionsAPI } from './api.js';
+import { fetchExercisesFromAPI } from './api.js';
 import { showExerciseHistory } from './history.js';
+import { flattenExercise, takeStashedExercises, makeBatch, sendBatch, enqueueBatch, SESSION_SIZE } from './offline.js';
 
 let _renderExercise = () => {};
 
@@ -29,18 +30,27 @@ export async function fetchExercises() {
     }, 1000);
 
     try {
-        const data = await fetchExercisesFromAPI(state.currentTopicId);
+        let exercises;
+        if (navigator.onLine === false) {
+            // Known offline: don't even try the network, serve the stash.
+            exercises = takeStashedExercises(SESSION_SIZE, state.currentTopicId);
+        } else {
+            try {
+                const data = await fetchExercisesFromAPI(state.currentTopicId);
+                exercises = (data.exercises || []).map(flattenExercise);
+            } catch (error) {
+                // Network (or server) failure: fall back to the offline stash.
+                // With an empty stash there is nothing to serve, so let the
+                // original error reporting below handle it.
+                exercises = takeStashedExercises(SESSION_SIZE, state.currentTopicId);
+                if (exercises.length === 0) throw error;
+                console.warn('Serving exercises from the offline cache:', error);
+            }
+        }
 
-        if (data.exercises && data.exercises.length > 0) {
-            state.exercises = data.exercises.map(ex => ({
-                ...ex.exercise_json,
-                id: ex.id,
-                audio_file_path: ex.audio_file_path,
-                is_favorite: ex.is_favorite || false,
-                topic_id: ex.topic_id,
-                repetition_counter: ex.repetition_counter || 0
-            }));
-            state.exerciseIds = data.exercises.map(ex => ex.id);
+        if (exercises.length > 0) {
+            state.exercises = exercises;
+            state.exerciseIds = exercises.map(ex => ex.id);
             state.currentExerciseIndex = 0;
             state.mistakes = 0;
             state.hintsUsed = 0;
@@ -59,6 +69,9 @@ export async function fetchExercises() {
 
             state.startTime = Date.now();
             _renderExercise();
+        } else if (navigator.onLine === false) {
+            alert('You are offline and no exercises are cached for offline practice.\nReconnect and press "Update offline cache" to download some.');
+            _renderExercise(); // Render empty state
         } else {
             // This can happen if generation fails or cache is empty and generation is disabled
             alert('No exercises could be retrieved for this topic. Please try another topic or contact support.');
@@ -271,26 +284,29 @@ export function resetForSameExercises() {
 }
 
 export async function saveUserStats() {
-    try {
-        await saveUserStatsAPI({
-            total_exercises: state.exercises.length,
-            total_mistakes: state.mistakes,
-            total_hints: state.hintsUsed,
-            total_time: state.sessionTime,
-        });
+    const stats = {
+        total_exercises: state.exercises.length,
+        total_mistakes: state.mistakes,
+        total_hints: state.hintsUsed,
+        total_time: state.sessionTime,
+    };
 
-        // Save per-exercise completion data — only exercises actually finished by the user
-        const completions = [];
-        state.completedExerciseIds.forEach((exerciseId) => {
-            const perf = state.exercisePerformance.get(exerciseId) || { hints: 0, mistakes: 0 };
-            completions.push({
-                exercise_id: exerciseId,
-                hints_used: perf.hints,
-                mistakes: perf.mistakes
-            });
+    // Per-exercise completion data — only exercises actually finished by the user
+    const completions = [];
+    state.completedExerciseIds.forEach((exerciseId) => {
+        const perf = state.exercisePerformance.get(exerciseId) || { hints: 0, mistakes: 0 };
+        completions.push({
+            exercise_id: exerciseId,
+            hints_used: perf.hints,
+            mistakes: perf.mistakes
         });
-        await saveExerciseCompletionsAPI(completions);
-    } catch (error) {
-        console.error('Error saving user stats:', error);
+    });
+
+    // Anything that doesn't land (offline, server error) is queued and retried
+    // later instead of being dropped. sendBatch clears the parts that landed.
+    const batch = makeBatch(stats, completions);
+    const delivered = await sendBatch(batch);
+    if (!delivered) {
+        enqueueBatch(batch);
     }
 }

--- a/js/state.js
+++ b/js/state.js
@@ -5,7 +5,8 @@ const RECENTLY_USED_TOPICS_STORAGE_KEY = 'recentlyUsedTopics';
 
 let localStorageErrorShown = false; // Prevent multiple notifications for localStorage errors
 
-function _showLocalStorageError(context) {
+// Shared by every module that persists to localStorage (state, audio, offline).
+export function showLocalStorageError(context) {
     if (!localStorageErrorShown) {
         localStorageErrorShown = true;
         alert(`Warning: Unable to save your preferences to local storage. Your changes may not persist after closing the browser.\n\nContext: ${context}`);
@@ -45,7 +46,7 @@ function _saveTopicCollapseState(collapsedIds) {
         localStorage.setItem(TOPIC_COLLAPSE_STATE_STORAGE_KEY, JSON.stringify([...collapsedIds]));
     } catch (error) {
         console.error('Failed to save topic collapse state:', error);
-        _showLocalStorageError('topic collapse state');
+        showLocalStorageError('topic collapse state');
     }
 }
 
@@ -76,7 +77,7 @@ function _saveRecentlyUsedTopics(topics) {
         localStorage.setItem(RECENTLY_USED_TOPICS_STORAGE_KEY, JSON.stringify(topics.slice(0, 10)));
     } catch (error) {
         console.error('Failed to save recently used topics:', error);
-        _showLocalStorageError('recently used topics');
+        showLocalStorageError('recently used topics');
     }
 }
 

--- a/js/topics.js
+++ b/js/topics.js
@@ -326,9 +326,44 @@ export function getFileIcon() {
     </svg>`;
 }
 
-export async function loadTopics() {
+export const TOPICS_CACHE_KEY = 'topicsCacheV1';
+
+function cacheTopicsPayload(data) {
     try {
-        const data = await fetchTopicsAPI();
+        localStorage.setItem(TOPICS_CACHE_KEY, JSON.stringify(data));
+    } catch (error) {
+        console.error('Failed to cache topics:', error);
+    }
+}
+
+function readCachedTopicsPayload() {
+    try {
+        const raw = localStorage.getItem(TOPICS_CACHE_KEY);
+        if (!raw) return null;
+        const parsed = JSON.parse(raw);
+        return parsed && Array.isArray(parsed.topics) ? parsed : null;
+    } catch (error) {
+        console.error('Failed to read cached topics:', error);
+        return null;
+    }
+}
+
+export async function loadTopics() {
+    let data;
+    try {
+        data = await fetchTopicsAPI();
+        cacheTopicsPayload(data);
+    } catch (error) {
+        console.error('Error loading topics:', error);
+        // Offline / server down: the last good topic tree keeps the UI usable.
+        data = readCachedTopicsPayload();
+        if (!data) {
+            alert('Failed to load topics. Please refresh the page.');
+            return;
+        }
+    }
+
+    try {
         state.topics = data.topics || [];
 
         renderTopicsList();
@@ -352,8 +387,7 @@ export async function loadTopics() {
             dom.topicSearch.value = getTopicPath(currentTopic.id, state.topics);
         }
     } catch (error) {
-        console.error('Error loading topics:', error);
-        alert('Failed to load topics. Please refresh the page.');
+        console.error('Error rendering topics:', error);
     }
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,18 @@
+{
+  "name": "German Grammar Trainer",
+  "short_name": "Grammar",
+  "description": "Practice German grammar with word-scramble exercises, online or offline.",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#FDF8F0",
+  "theme_color": "#A33F11",
+  "icons": [
+    {
+      "src": "/favicon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    }
+  ]
+}

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,99 @@
+/* Service worker for offline practice sessions.
+ *
+ * Strategy:
+ *   - shell (/, css, js modules, favicons, manifest): cache-first, precached on install
+ *   - /audio_cache/*: cache-first (content-addressed + immutable), silent miss offline
+ *   - /api/*: never touched — always network
+ *   - CDN chart.js + Google Fonts: runtime cache-first, best effort (opaque responses)
+ *
+ * IMPORTANT: bump CACHE_VERSION whenever a shell file changes, otherwise
+ * returning visitors keep the old cached copy until the cache is evicted.
+ */
+const CACHE_VERSION = 'gct-shell-v1';
+
+const SHELL_ASSETS = [
+    '/',
+    '/style.css',
+    '/manifest.json',
+    '/favicon.svg',
+    '/favicon-32x32.svg',
+    '/js/main.js',
+    '/js/state.js',
+    '/js/dom.js',
+    '/js/api.js',
+    '/js/audio.js',
+    '/js/auth.js',
+    '/js/exercise.js',
+    '/js/history.js',
+    '/js/offline.js',
+    '/js/session.js',
+    '/js/topics.js',
+    // Third-party shell dependencies — best effort, a failure here is fine.
+    'https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.5.0/chart.umd.min.js',
+    'https://fonts.googleapis.com/css2?family=Nunito+Sans:wght@400;600;700;800&display=swap',
+];
+
+const RUNTIME_CACHE_HOSTS = [
+    'cdnjs.cloudflare.com',
+    'fonts.googleapis.com',
+    'fonts.gstatic.com',
+];
+
+self.addEventListener('install', (event) => {
+    event.waitUntil((async () => {
+        const cache = await caches.open(CACHE_VERSION);
+        // Individual adds (not addAll) so one 404 doesn't abort the whole install.
+        await Promise.allSettled(SHELL_ASSETS.map((asset) => cache.add(asset)));
+        await self.skipWaiting();
+    })());
+});
+
+self.addEventListener('activate', (event) => {
+    event.waitUntil((async () => {
+        const names = await caches.keys();
+        await Promise.all(names.filter((name) => name !== CACHE_VERSION).map((name) => caches.delete(name)));
+        await self.clients.claim();
+    })());
+});
+
+async function cacheFirst(request) {
+    const cache = await caches.open(CACHE_VERSION);
+    // ignoreSearch: index.html references style.css?v=..., and navigations can
+    // carry query strings (?debug=true) that must still hit the cached shell.
+    const cached = await cache.match(request, { ignoreSearch: true });
+    if (cached) return cached;
+
+    try {
+        const response = await fetch(request);
+        // Only full 200s are cacheable — cache.put rejects 206 range responses.
+        if (response && (response.status === 200 || response.type === 'opaque')) {
+            cache.put(request, response.clone()).catch(() => {});
+        }
+        return response;
+    } catch (error) {
+        if (request.mode === 'navigate') {
+            const shell = await cache.match('/', { ignoreSearch: true });
+            if (shell) return shell;
+        }
+        // Offline miss (e.g. audio that was never warmed) — fail silently.
+        return Response.error();
+    }
+}
+
+self.addEventListener('fetch', (event) => {
+    const request = event.request;
+    if (request.method !== 'GET') return;
+
+    const url = new URL(request.url);
+
+    if (url.origin === self.location.origin) {
+        if (url.pathname.startsWith('/api/') || url.pathname.startsWith('/auth/')) return;
+        if (url.pathname === '/sw.js') return;
+        event.respondWith(cacheFirst(request));
+        return;
+    }
+
+    if (RUNTIME_CACHE_HOSTS.includes(url.hostname)) {
+        event.respondWith(cacheFirst(request));
+    }
+});


### PR DESCRIPTION
Implements bead `german-conjuctions-trainer-9c9.2`: a logged-in user can pre-download exercises + audio, practice fully offline, and have the results sync when connectivity returns.

## What landed

**Service worker + PWA glue**
- `sw.js` (root scope) and `manifest.json`, registered from `init()` in `js/main.js`.
- Strategy: versioned cache-first shell (`/`, `style.css`, every `js/*.js` module, favicons, manifest) with activate-time cleanup of old versions; cache-first for `/audio_cache/*` (content-addressed, immutable, silent miss offline); **never** intercepts `/api/*` or `/auth/*`; best-effort runtime cache for the chart.js CDN + Google Fonts (also precached so the stats page survives offline).
- `CACHE_VERSION = 'gct-shell-v1'` — comment in the file says to bump it on any shell change.
- Go glue in `internal/app/static.go` + `app.go` follows the existing per-file pattern: `/sw.js` (`application/javascript`, `Cache-Control: no-cache`, `Service-Worker-Allowed: /`) and `/manifest.json` (`application/manifest+json`). Both files added to the Dockerfile `COPY` line.

**"Update offline cache" button** (`index.html` header, logged-in only via `updateAuthUI`)
- Flushes the completion queue, then fetches the selected topic (`POST /api/exercises`) plus each `state.recentlyUsedTopics` entry with `{limit: 25, skip_generation: true}`, dedupes by exercise id, caps at 100.
- **Replaces** `offlineStashV1` each run (idempotent, re-clickable), then warms audio: `fetch()` on each `audio_file_path` (SW caches it) and `preloadExerciseWordAudio` per exercise, sequentially (it keeps its own 3-worker concurrency). Individual audio failures never abort the run.
- Progress text next to the button (`12/40…`), done state with count + timestamp, button disabled while running.

**Offline serving** (`js/session.js`)
- `fetchExercises` skips the network entirely when `navigator.onLine === false`, and falls back to the stash when the fetch rejects. Served exercises are removed from the stash. Empty stash while offline gets a clearer alert; online errors keep the existing 429/504/generic handling. Grading and rendering are untouched.

**Completion queue** (`offlineQueueV1`)
- `saveUserStats` builds a batch with a `crypto.randomUUID()` `client_batch_id` and queues it if either POST fails — this also fixes an existing **online** data-loss bug: `saveUserStatsAPI`/`saveExerciseCompletionsAPI` never checked `response.ok`, so a 500 silently dropped the session.
- Partial success clears the delivered half of the batch so a retry can't double-count the stats aggregate.
- Flushed on `init()`, on the window `online` event, and at the start of the update-cache flow; an in-flight guard prevents overlapping flushes. Entries are removed only on full success.

**Offline UI survival**
- `loadTopics` caches the last good payload (`topicsCacheV1`) and falls back to it instead of alerting.
- `checkAuthStatus` persists the last known status (`authStatusV1`) and restores it when `/api/auth/status` is unreachable, so the logged-in UI (and the offline button) stay visible offline.

**Housekeeping**
- Hoisted the duplicated `_showLocalStorageError` into `state.js` as an export; `audio.js` now imports it (no third copy).
- `preloadExerciseWordAudio` now returns its promise so the warm-up can await it. Existing callers are unaffected.

## Tests
- New `js/__tests__/offline.test.js`: flatten, stash round-trip/corruption/topic-preference/consumption, `sendBatch` partial-failure semantics, queue append/flush/idempotency-key-reuse/offline no-op, `updateOfflineCache` dedupe + replace + flush-first.
- `js/__tests__/session.test.js`: stash fallback on fetch failure, offline short-circuit, offline-specific alert, original error still surfaced when online with an empty stash, queueing on POST failure.
- New `js/__tests__/auth.test.js` and `js/__tests__/topics.test.js`: cache-write + fallback + no-cache paths.
- Per the owner directive the frontend suite was **not** run locally — CI is the gate. Go side verified locally: `make vet` and `make test` both pass.

## Known deferrals / honest flags
1. **Backend contract not merged yet.** `limit` / `skip_generation` on `/api/exercises` and `client_batch_id` on `/api/exercises/complete` are coded to the agreed contract; the current server ignores unknown JSON fields. Until the parallel backend PR lands: (a) warming a thin recent topic can still trigger AI generation instead of a cheap cache-only read, and (b) a retry after a lost response can double-count one batch. Both are flagged in code comments at the call sites. (b) is still strictly better than today's silent drop.
2. **Not manually verified in a browser.** No DevTools-offline pass was done in this environment — the SW strategy, cache warm-up and offline session flow are reasoned from the code, not observed. Worth one manual run of the acceptance checklist before merge.
3. Chart.js and the Google Fonts stylesheet are precached from their CDN URLs; if a CSP or a CDN hiccup blocks them, `install` still succeeds (`allSettled`) and only the session stats chart degrades offline.
4. No IndexedDB, no workbox, no new dependencies, and `internal/app/exercises.go`, `srs.go`, `pkg/storage` were not touched.
