### PR TITLE
fix: stash a real offline batch instead of ~10 exercises

### DIFF
--- a/internal/app/exercises.go
+++ b/internal/app/exercises.go
@@ -16,7 +16,7 @@ import (
 const (
 	// maxExerciseBatchLimit is the hard cap on the "limit" field of
 	// POST /api/exercises, so an offline prefetch cannot ask for the world.
-	maxExerciseBatchLimit = 50
+	maxExerciseBatchLimit = 200
 	// maxClientBatchIDLen bounds the client-supplied idempotency key.
 	maxClientBatchIDLen = 64
 )
@@ -50,7 +50,7 @@ func (a *App) handleExercises(w http.ResponseWriter, r *http.Request) {
 
 	userID := getUserIDFromRequest(r)
 
-	// Batch size: default 10, hard cap 50 (offline prefetch asks for more).
+	// Batch size: default 10, hard cap maxExerciseBatchLimit (offline prefetch asks for more).
 	limit := 10
 	if req.Limit > 0 {
 		limit = req.Limit
@@ -103,7 +103,7 @@ func (a *App) handleExercises(w http.ResponseWriter, r *http.Request) {
 	userViews := make(map[string]*storage.UserExerciseView)
 	if userID == "" {
 		log.Printf("[EXERCISES] Guest user mode - serving random exercises from cache")
-		finalExercises = getRandomExercises(allExercises, 10)
+		finalExercises = getRandomExercises(allExercises, limit)
 	} else {
 		log.Printf("[EXERCISES] Authenticated user %s - applying SRS logic", userID)
 		var err error

--- a/internal/app/exercises_integration_test.go
+++ b/internal/app/exercises_integration_test.go
@@ -105,7 +105,7 @@ func TestExerciseIntegration_ChangingPromptFiltersOutOldExercises(t *testing.T) 
 	// Request exercises. Since none match newHash, it should trigger generation.
 	// We'll use an unauthenticated user, wait, guest user gets randomly selected from the filtered list.
 	// If the list is empty, guest user gets empty list? Let's check handleExercises logic:
-	// "if userID == "" { ... finalExercises = getRandomExercises(allExercises, 10) }"
+	// "if userID == "" { ... finalExercises = getRandomExercises(allExercises, limit) }"
 	// So for guest user, it will return 0 exercises.
 
 	reqBody, _ := json.Marshal(llm.GenerateRequest{TopicID: topic.ID})

--- a/internal/app/exercises_offline_test.go
+++ b/internal/app/exercises_offline_test.go
@@ -40,7 +40,7 @@ func TestExerciseBatchLimit(t *testing.T) {
 	topic := &storage.Topic{ID: "t1", Prompt: "my prompt"}
 	mock.topics["t1"] = topic
 	hash := storage.GetPromptHash(topic.Prompt)
-	for i := 0; i < 60; i++ {
+	for i := 0; i < maxExerciseBatchLimit+10; i++ {
 		mock.exercises = append(mock.exercises, &storage.Exercise{
 			ID: fmt.Sprintf("ex%d", i), TopicID: "t1", PromptHash: hash, ExerciseJSON: `{"test":"test"}`,
 		})
@@ -53,7 +53,8 @@ func TestExerciseBatchLimit(t *testing.T) {
 	}{
 		{"default is 10", 0, 10},
 		{"explicit limit honoured", 25, 25},
-		{"limit above cap clamps to 50", 100, 50},
+		{"large limit honoured", 150, 150},
+		{"limit above cap clamps", 1000, maxExerciseBatchLimit},
 	}
 
 	for _, tc := range tests {

--- a/internal/app/exercises_selection_test.go
+++ b/internal/app/exercises_selection_test.go
@@ -266,22 +266,32 @@ func TestExerciseSelection_GuestUserPath(t *testing.T) {
 		mock.exercises = append(mock.exercises, &storage.Exercise{ID: string(rune(i)), TopicID: "t1", PromptHash: currentHash, ExerciseJSON: `{"test":"test"}`})
 	}
 
-	reqBody, _ := json.Marshal(llm.GenerateRequest{TopicID: "t1"})
-	req := httptest.NewRequest("POST", "/api/exercises", bytes.NewReader(reqBody))
-	req.Header.Set("Content-Type", "application/json")
+	guestCount := func(limit int) int {
+		t.Helper()
+		reqBody, _ := json.Marshal(llm.GenerateRequest{TopicID: "t1", Limit: limit})
+		req := httptest.NewRequest("POST", "/api/exercises", bytes.NewReader(reqBody))
+		req.Header.Set("Content-Type", "application/json")
 
-	rr := httptest.NewRecorder()
-	app.handleExercises(rr, req)
+		rr := httptest.NewRecorder()
+		app.handleExercises(rr, req)
 
-	if rr.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d", rr.Code)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", rr.Code)
+		}
+
+		var resp map[string][]map[string]interface{}
+		json.Unmarshal(rr.Body.Bytes(), &resp)
+		return len(resp["exercises"])
 	}
 
-	var resp map[string][]map[string]interface{}
-	json.Unmarshal(rr.Body.Bytes(), &resp)
-
-	exercises := resp["exercises"]
-	if len(exercises) != 10 { // capped at 10
-		t.Errorf("expected 10 exercises, got %d", len(exercises))
+	if got := guestCount(0); got != 10 { // default batch size
+		t.Errorf("expected 10 exercises, got %d", got)
+	}
+	// The offline prefetch asks for more than the default; guests get it too.
+	if got := guestCount(15); got != 15 {
+		t.Errorf("expected 15 exercises for limit=15, got %d", got)
+	}
+	if got := guestCount(maxExerciseBatchLimit + 1); got != 15 { // clamped, then content-bound
+		t.Errorf("expected all 15 cached exercises, got %d", got)
 	}
 }

--- a/js/__tests__/offline.test.js
+++ b/js/__tests__/offline.test.js
@@ -199,8 +199,8 @@ describe('offline.js', () => {
 
             await updateOfflineCache();
 
-            expect(api.fetchExercisesFromAPI).toHaveBeenNthCalledWith(1, 't1', {});
-            expect(api.fetchExercisesFromAPI).toHaveBeenNthCalledWith(2, 't2', { limit: 25, skip_generation: true });
+            expect(api.fetchExercisesFromAPI).toHaveBeenNthCalledWith(1, 't1', { limit: 200 });
+            expect(api.fetchExercisesFromAPI).toHaveBeenNthCalledWith(2, 't2', { limit: 50, skip_generation: true });
             expect(readStash().exercises.map(e => e.id)).toEqual(['a', 'b', 'c']);
         });
 

--- a/js/offline.js
+++ b/js/offline.js
@@ -9,10 +9,12 @@ import { preloadExerciseWordAudio } from './audio.js';
 export const OFFLINE_STASH_KEY = 'offlineStashV1';
 export const OFFLINE_QUEUE_KEY = 'offlineQueueV1';
 
-const MAX_STASHED_EXERCISES = 100;
-const PER_TOPIC_STASH_LIMIT = 25;
+const MAX_STASHED_EXERCISES = 500;
+const PER_TOPIC_STASH_LIMIT = 50;
+// Current topic gets the server's hard cap (internal/app/exercises.go).
+const CURRENT_TOPIC_STASH_LIMIT = 200;
 
-// Server-side session size (internal/app/exercises.go returns at most 10).
+// Server-side session size (internal/app/exercises.go default batch is 10).
 export const SESSION_SIZE = 10;
 
 function newBatchId() {
@@ -216,15 +218,12 @@ export async function updateOfflineCache() {
         const byId = new Map();
 
         if (state.currentTopicId) {
-            for (const ex of await fetchForStash(state.currentTopicId, {})) {
+            // No skip_generation here: the current topic is worth generating for.
+            for (const ex of await fetchForStash(state.currentTopicId, { limit: CURRENT_TOPIC_STASH_LIMIT })) {
                 byId.set(ex.id, ex);
             }
         }
 
-        // limit + skip_generation are honoured by the /api/exercises change
-        // shipping in a parallel backend PR. Until that lands the server
-        // ignores them (unknown JSON fields), so a warm-up of a thin topic can
-        // still trigger generation — correct, just slower and more expensive.
         for (const topic of state.recentlyUsedTopics) {
             if (byId.size >= MAX_STASHED_EXERCISES) break;
             if (topic.id === state.currentTopicId) continue;


### PR DESCRIPTION
Fixes german-conjuctions-trainer-3rs — "Update offline cache" stashed only ~10 exercises.

## Root cause

- `js/offline.js` fetched the current topic with `{}`, so the server's default batch of 10 applied.
- `internal/app/exercises.go` hard-capped any request at 50, and the guest path called `getRandomExercises(allExercises, 10)`, ignoring `limit` entirely.

## Changes

Backend (`internal/app/exercises.go`):
- `maxExerciseBatchLimit` 50 -> 200.
- Guest path uses `limit` instead of the hardcoded 10.

Frontend (`js/offline.js`):
- `MAX_STASHED_EXERCISES` 100 -> 500, `PER_TOPIC_STASH_LIMIT` 25 -> 50.
- Current-topic fetch passes `{ limit: 200 }` and deliberately keeps generation enabled (no `skip_generation`) — the topic you are actually working on is worth generating for. Recent topics keep `skip_generation: true`.
- Dropped the stale comment claiming `limit`/`skip_generation` ship "in a parallel backend PR" — that landed in #81.

Tests: limit table now covers a large limit and clamping at `maxExerciseBatchLimit`; the guest test asserts `limit` is honoured and clamped. Frontend test asserts the new per-call options.

## Not changed, on purpose

SRS eligibility (`getEligibleExercisesForSRS`) is untouched. The stash intentionally holds only due + unseen exercises, so a thin or heavily practiced topic will stash fewer than the limit. That is content-bound and expected, not a bug — loosening eligibility would stash exercises the user is not due for.

localStorage stays the store: 500 exercises at ~1KB each is well inside the ~5MB budget, no IndexedDB migration.

## Verification

`go build ./...` and `go test ./...` green locally. Frontend is gated by CI only.
`codex review --base master`: no findings.
